### PR TITLE
feat: Member 도메인 리팩토링 & Member RUD API 추가

### DIFF
--- a/src/main/java/com/writingboard/server/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/writingboard/server/domain/auth/service/CustomOAuth2UserService.java
@@ -21,7 +21,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberRepository memberRepository;
 
     @Override
-    @Transactional // 저장 로직이 있으므로 트랜잭션 추가
+    @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);

--- a/src/main/java/com/writingboard/server/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/writingboard/server/domain/auth/service/CustomOAuth2UserService.java
@@ -9,6 +9,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 
@@ -20,30 +21,29 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberRepository memberRepository;
 
     @Override
+    @Transactional // 저장 로직이 있으므로 트랜잭션 추가
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        // 1. 구글에서 유저 정보 가져오기
+
         OAuth2User oAuth2User = super.loadUser(userRequest);
         log.info("구글 로그인 정보: {}", oAuth2User.getAttributes());
 
-        // 2. 정보 추출
-        String provider = userRequest.getClientRegistration().getRegistrationId(); // "google"
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
         String email = (String) attributes.get("email");
         String name = (String) attributes.get("name");
-        String providerId = (String) attributes.get("sub"); // 구글의 PK
+        String providerId = (String) attributes.get("sub");
+        String picture = (String) attributes.get("picture");
 
-        // 3. DB 저장 (있으면 패스, 없으면 저장)
         Member member = memberRepository.findByEmail(email)
+                .map(entity -> {
+                    entity.updateProfile(name, picture);
+                    return entity;
+                })
                 .orElseGet(() -> {
                     log.info("신규 회원가입: {}", email);
-                    return memberRepository.save(Member.builder()
-                            .email(email)
-                            .name(name)
-                            .providerId(providerId)
-                            .build());
+                    return memberRepository.save(Member.create(email, name, providerId, picture));
                 });
 
-        return oAuth2User; // 일단 리턴 (나중에 여기서 CustomUserDetail 리턴해야 함)
+        return oAuth2User;
     }
 }

--- a/src/main/java/com/writingboard/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/writingboard/server/domain/member/controller/MemberController.java
@@ -1,0 +1,47 @@
+package com.writingboard.server.domain.member.controller;
+
+import com.writingboard.server.domain.member.dto.request.MemberUpdateRequest;
+import com.writingboard.server.domain.member.dto.response.MemberProfileResponse;
+import com.writingboard.server.domain.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * 내 정보 조회
+     */
+    @GetMapping("/me")
+    public ResponseEntity<MemberProfileResponse> getMyProfile(
+            @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(memberService.getMyProfile(memberId));
+    }
+
+    /**
+     * 내 정보 수정
+     */
+    @PatchMapping("/me")
+    public ResponseEntity<MemberProfileResponse> updateMyProfile(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid MemberUpdateRequest request) {
+        return ResponseEntity.ok(memberService.updateProfile(memberId, request));
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(
+            @AuthenticationPrincipal Long memberId) {
+        memberService.withdraw(memberId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/member/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/member/dto/request/MemberUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.writingboard.server.domain.member.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberUpdateRequest {
+
+    @Size(max = 50, message = "닉네임은 2자 이상 50자 이하이어야 합니다.")
+    private String name;
+
+    @Size(max = 500, message = "URL 길이가 너무 깁니다.")
+    private String profileImageUrl;
+}

--- a/src/main/java/com/writingboard/server/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/writingboard/server/domain/member/dto/response/MemberProfileResponse.java
@@ -1,0 +1,24 @@
+package com.writingboard.server.domain.member.dto.response;
+
+import com.writingboard.server.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberProfileResponse {
+
+    private Long memberId;
+    private String email;
+    private String name;
+    private String profileImageUrl;
+
+    public static MemberProfileResponse of(Member member) {
+        return MemberProfileResponse.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .profileImageUrl(member.getProfileImageUrl()) // 엔티티에서 꺼내서 넣음
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/member/entity/Member.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/Member.java
@@ -1,38 +1,67 @@
 package com.writingboard.server.domain.member.entity;
 
+import com.writingboard.server.domain.member.entity.enums.MemberStatus;
+import com.writingboard.server.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
+@Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+@AllArgsConstructor(access = AccessLevel.PRIVATE) // create 메서드 사용 유도
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(name = "email", length = 100, nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column(name = "name", length = 50, nullable = false)
     private String name;
 
-    @Column(nullable = false)
-    private String providerId; // 구글의 고유 ID (sub)
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl; // 지금은 안 씀
 
-    private LocalDateTime createdAt;
+    @Column(name = "provider_id", length = 100, nullable = false)
+    private String providerId; // Google sub ID
 
-    @Builder
-    public Member(String email, String name, String providerId) {
-        this.email = email;
-        this.name = name;
-        this.providerId = providerId;
-        this.createdAt = LocalDateTime.now();
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private MemberStatus status = MemberStatus.ACTIVE;
+
+
+    public static Member create(String email, String name, String providerId, String profileImageUrl) {
+        Member member = new Member();
+        member.email = email;
+        member.name = name;
+        member.providerId = providerId;
+        member.profileImageUrl = profileImageUrl;
+        member.status = MemberStatus.ACTIVE;
+        return member;
+    }
+
+
+    public void updateProfile(String name, String profileImageUrl) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (profileImageUrl != null && !profileImageUrl.isBlank()) {
+            this.profileImageUrl = profileImageUrl;
+        }
+    }
+
+    public void withdraw() {
+        this.status = MemberStatus.DELETED;
+    }
+
+    public boolean isDeleted() {
+        return this.status == MemberStatus.DELETED;
     }
 }

--- a/src/main/java/com/writingboard/server/domain/member/entity/enums/MemberStatus.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/enums/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.member.entity.enums;
+
+public enum MemberStatus {
+    ACTIVE,   // 활동 중
+    DELETED   // 탈퇴함
+}

--- a/src/main/java/com/writingboard/server/domain/member/entity/enums/MemberStatus.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/enums/MemberStatus.java
@@ -1,6 +1,6 @@
 package com.writingboard.server.domain.member.entity.enums;
 
 public enum MemberStatus {
-    ACTIVE,   // 활동 중
-    DELETED   // 탈퇴함
+    ACTIVE,
+    DELETED
 }

--- a/src/main/java/com/writingboard/server/domain/member/exception/ErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/member/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.writingboard.server.domain.member.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // Member 관련 (MEMBER_XXX)
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "사용자를 찾을 수 없습니다."),
+    ALREADY_DELETED(HttpStatus.BAD_REQUEST, "MEMBER_002", "이미 탈퇴한 회원입니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "MEMBER_003", "잘못된 입력값입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "MEMBER_004", "이미 존재하는 이메일입니다."),
+
+    // Auth 관련 (AUTH_XXX) 일단 여기 나중에 옮길거
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 만료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/writingboard/server/domain/member/exception/MemberException.java
+++ b/src/main/java/com/writingboard/server/domain/member/exception/MemberException.java
@@ -1,0 +1,14 @@
+package com.writingboard.server.domain.member.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MemberException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/writingboard/server/domain/member/service/MemberService.java
@@ -32,7 +32,6 @@ public class MemberService {
     public MemberProfileResponse updateProfile(Long memberId, MemberUpdateRequest request) {
         Member member = getMemberById(memberId);
 
-        // 엔티티 비즈니스 메서드 호출 (Dirty Checking)
         member.updateProfile(request.getName(), request.getProfileImageUrl());
 
         return MemberProfileResponse.of(member);
@@ -46,7 +45,6 @@ public class MemberService {
     public void withdraw(Long memberId) {
         Member member = getMemberById(memberId);
 
-        // 이미 탈퇴했는지 재확인
         if (member.isDeleted()) {
             throw new MemberException(ErrorCode.ALREADY_DELETED);
         }

--- a/src/main/java/com/writingboard/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/writingboard/server/domain/member/service/MemberService.java
@@ -1,0 +1,67 @@
+package com.writingboard.server.domain.member.service;
+
+import com.writingboard.server.domain.member.dto.request.MemberUpdateRequest;
+import com.writingboard.server.domain.member.dto.response.MemberProfileResponse;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.exception.ErrorCode;
+import com.writingboard.server.domain.member.exception.MemberException;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 내 정보 조회
+     */
+    public MemberProfileResponse getMyProfile(Long memberId) {
+        Member member = getMemberById(memberId);
+        return MemberProfileResponse.of(member);
+    }
+
+    /**
+     * 내 정보 수정 (이름, 프로필 사진)
+     */
+    @Transactional
+    public MemberProfileResponse updateProfile(Long memberId, MemberUpdateRequest request) {
+        Member member = getMemberById(memberId);
+
+        // 엔티티 비즈니스 메서드 호출 (Dirty Checking)
+        member.updateProfile(request.getName(), request.getProfileImageUrl());
+
+        return MemberProfileResponse.of(member);
+    }
+
+
+    /**
+     * 회원 탈퇴 (Soft Delete)
+     */
+    @Transactional
+    public void withdraw(Long memberId) {
+        Member member = getMemberById(memberId);
+
+        // 이미 탈퇴했는지 재확인
+        if (member.isDeleted()) {
+            throw new MemberException(ErrorCode.ALREADY_DELETED);
+        }
+
+        member.withdraw();
+    }
+
+
+    private Member getMemberById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.isDeleted()) {
+            throw new MemberException(ErrorCode.ALREADY_DELETED);
+        }
+        return member;
+    }
+}

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.writingboard.server.global.exception;
 
 import com.writingboard.server.domain.meeting.exception.MeetingException;
+import com.writingboard.server.domain.member.exception.MemberException;
 import com.writingboard.server.global.common.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MeetingException.class)
     public ResponseEntity<ErrorResponse> handleMeetingException(MeetingException e) {
         log.warn("MeetingException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
+        log.warn("MemberException: {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));


### PR DESCRIPTION
#5 

Member Entity 리팩토링: Column 명시, Enum 생성 등
MemberService/Controller 구현: 내 정보 조회/수정/탈퇴 및 이메일 검색 API 추가
예외 처리 고도화: MemberException 및 도메인별 ErrorCode(MEMBER_XXX) 분리 적용
데이터 검증: DTO에 @Valid 적용 (일단 길이만 하긴 했어요)
기존 Room API 동작 확인

TODO:
auth 도메인 리팩토링, jwt 재발급 api 추가, swagger 인증 간단하게? (지금 넘 복잡함)
signaling 하기