### PR TITLE
feat: 채팅 기능 및 채팅 기록 저장/조회 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,11 @@ DB_USER=yoon9531
 DB_PASSWORD=admin1234
 
 # Redis setting
-REDIS_PASSWORD=my_secure_password123
+REDIS_PASSWORD=admin1234
 
 # MongoDB Setting
-MONGO_USER=admin1234
-MONGO_PASSWORD=admin1234
+MONGO_USER=yoon9531
+MONGO_PASSWORD=testpasswordadmin1234
 
 # JWT Secret (32자 이상 아무거나)
 JWT_SECRET=

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15"
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     volumes:
       - ./data/redis:/data
 
-  # 3. MongoDB (Chat History Storage)
+  # 3. MongoDB
   mongo:
     image: mongo:latest
     container_name: writing-board-mongo
@@ -38,5 +38,6 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: writing_db
     volumes:
       - ./data/mongo:/data/db

--- a/src/main/java/com/writingboard/server/domain/chat/controller/ChatHistoryController.java
+++ b/src/main/java/com/writingboard/server/domain/chat/controller/ChatHistoryController.java
@@ -1,0 +1,43 @@
+package com.writingboard.server.domain.chat.controller;
+
+import com.writingboard.server.domain.chat.dto.response.ChatHistoryResponse;
+import com.writingboard.server.domain.chat.service.ChatHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+
+@Tag(name = "Chat", description = "채팅 API")
+@RestController
+@RequestMapping("/api/rooms/{roomUuid}/messages")
+@RequiredArgsConstructor
+public class ChatHistoryController {
+
+    private final ChatHistoryService chatHistoryService;
+
+    /**
+     * 채팅 기록 조회 (커서 기반 페이징)
+     * - 진행 중인 회의실: 현재 참여자만 조회 가능
+     * - 종료된 회의실: 참여 이력이 있는 사용자만 조회 가능
+     */
+    @Operation(summary = "채팅 기록 조회", description = "회의실의 채팅 기록을 커서 기반으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ChatHistoryResponse> getMessages(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @Parameter(description = "이 시각 이전의 메시지를 조회 (ISO-8601 형식)")
+            @RequestParam(required = false) Instant before,
+            @Parameter(description = "조회할 메시지 수 (기본: 50, 최대: 100)")
+            @RequestParam(defaultValue = "50") @Max(100) Integer limit) {
+
+        return ResponseEntity.ok(
+                chatHistoryService.getMessages(memberId, roomUuid, before, limit)
+        );
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/controller/ChatHistoryController.java
+++ b/src/main/java/com/writingboard/server/domain/chat/controller/ChatHistoryController.java
@@ -22,11 +22,9 @@ public class ChatHistoryController {
     private final ChatHistoryService chatHistoryService;
 
     /**
-     * 채팅 기록 조회 (커서 기반 페이징)
-     * - 진행 중인 회의실: 현재 참여자만 조회 가능
-     * - 종료된 회의실: 참여 이력이 있는 사용자만 조회 가능
+     * 채팅 기록 조회
      */
-    @Operation(summary = "채팅 기록 조회", description = "회의실의 채팅 기록을 커서 기반으로 조회합니다.")
+    @Operation(summary = "채팅 기록 조회")
     @GetMapping
     public ResponseEntity<ChatHistoryResponse> getMessages(
             @AuthenticationPrincipal Long memberId,

--- a/src/main/java/com/writingboard/server/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/writingboard/server/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,57 @@
+package com.writingboard.server.domain.chat.controller;
+
+import com.writingboard.server.domain.chat.dto.request.ChatMessageRequest;
+import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
+import com.writingboard.server.domain.chat.service.ChatService;
+import com.writingboard.server.global.websocket.StompPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final ChatService chatService;
+
+    /**
+     * 채팅 메시지 전송
+     * Client: STOMP SEND /app/room/{roomUuid}/chat
+     * Response: Redis Pub/Sub -> /topic/room/{roomUuid}
+     */
+    @MessageMapping("/room/{roomUuid}/chat")
+    public void handleChatMessage(
+            @DestinationVariable String roomUuid,
+            @Payload ChatMessageRequest request,
+            Principal principal) {
+
+        Long memberId = getMemberId(principal);
+        log.debug("채팅 메시지 수신: roomUuid={}, memberId={}", roomUuid, memberId);
+
+        chatService.sendMessage(memberId, roomUuid, request.getContent());
+    }
+
+    /**
+     * 에러 발생 시 개인 큐로 에러 메시지 전송
+     */
+    @MessageMapping("/room/{roomUuid}/chat")
+    @SendToUser("/queue/errors")
+    public String handleError(Exception e) {
+        log.error("채팅 메시지 처리 중 에러", e);
+        return e.getMessage();
+    }
+
+    private Long getMemberId(Principal principal) {
+        if (principal instanceof StompPrincipal stompPrincipal) {
+            return stompPrincipal.getMemberId();
+        }
+        throw new IllegalStateException("인증되지 않은 사용자입니다.");
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/writingboard/server/domain/chat/controller/ChatMessageController.java
@@ -7,6 +7,7 @@ import com.writingboard.server.global.websocket.StompPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.annotation.SendToUser;
@@ -23,8 +24,8 @@ public class ChatMessageController {
 
     /**
      * 채팅 메시지 전송
-     * Client: STOMP SEND /app/room/{roomUuid}/chat
-     * Response: Redis Pub/Sub -> /topic/room/{roomUuid}
+     * Client 전송 -> /app/room/{roomUuid}/chat
+     * Redis Pub/Sub -> /topic/room/{roomUuid}
      */
     @MessageMapping("/room/{roomUuid}/chat")
     public void handleChatMessage(
@@ -41,7 +42,7 @@ public class ChatMessageController {
     /**
      * 에러 발생 시 개인 큐로 에러 메시지 전송
      */
-    @MessageMapping("/room/{roomUuid}/chat")
+    @MessageExceptionHandler
     @SendToUser("/queue/errors")
     public String handleError(Exception e) {
         log.error("채팅 메시지 처리 중 에러", e);

--- a/src/main/java/com/writingboard/server/domain/chat/document/ChatMessage.java
+++ b/src/main/java/com/writingboard/server/domain/chat/document/ChatMessage.java
@@ -1,0 +1,69 @@
+package com.writingboard.server.domain.chat.document;
+
+import com.writingboard.server.domain.chat.enums.MessageType;
+import com.writingboard.server.domain.member.entity.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document(collection = "chat_messages")
+@CompoundIndex(name = "idx_room_timestamp", def = "{'roomUuid': 1, 'timestamp': -1}")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String roomUuid;
+
+    private Long senderId;
+    private String senderName;
+    private String senderProfileImage;
+
+    private String content;
+    private MessageType messageType;
+
+    @Indexed
+    private Instant timestamp;
+
+    private ChatMessage(String roomUuid, Long senderId, String senderName,
+                        String senderProfileImage, String content, MessageType messageType) {
+        this.roomUuid = roomUuid;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.senderProfileImage = senderProfileImage;
+        this.content = content;
+        this.messageType = messageType;
+        this.timestamp = Instant.now();
+    }
+
+    public static ChatMessage createText(String roomUuid, Member sender, String content) {
+        return new ChatMessage(
+                roomUuid,
+                sender.getId(),
+                sender.getName(),
+                sender.getProfileImageUrl(),
+                content,
+                MessageType.TEXT
+        );
+    }
+
+    public static ChatMessage createSystem(String roomUuid, String content) {
+        return new ChatMessage(
+                roomUuid,
+                null,
+                "SYSTEM",
+                null,
+                content,
+                MessageType.SYSTEM
+        );
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/writingboard/server/domain/chat/dto/request/ChatMessageRequest.java
@@ -2,18 +2,17 @@ package com.writingboard.server.domain.chat.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ChatMessageRequest {
 
     @NotBlank(message = "메시지 내용은 필수입니다")
     @Size(max = 2000, message = "메시지는 최대 2000자까지 가능합니다")
     private String content;
 
-    public ChatMessageRequest(String content) {
-        this.content = content;
-    }
 }

--- a/src/main/java/com/writingboard/server/domain/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/writingboard/server/domain/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,19 @@
+package com.writingboard.server.domain.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageRequest {
+
+    @NotBlank(message = "메시지 내용은 필수입니다")
+    @Size(max = 2000, message = "메시지는 최대 2000자까지 가능합니다")
+    private String content;
+
+    public ChatMessageRequest(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/dto/response/ChatHistoryResponse.java
+++ b/src/main/java/com/writingboard/server/domain/chat/dto/response/ChatHistoryResponse.java
@@ -1,0 +1,27 @@
+package com.writingboard.server.domain.chat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatHistoryResponse {
+
+    private List<ChatMessageDto> messages;
+    private boolean hasMore;
+    private Instant nextCursor;
+
+    public static ChatHistoryResponse of(List<ChatMessageDto> messages, int requestedLimit) {
+        boolean hasMore = messages.size() >= requestedLimit;
+        Instant nextCursor = messages.isEmpty() ? null : messages.get(messages.size() - 1).getTimestamp();
+
+        return ChatHistoryResponse.builder()
+                .messages(messages)
+                .hasMore(hasMore)
+                .nextCursor(nextCursor)
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/dto/response/ChatMessageDto.java
+++ b/src/main/java/com/writingboard/server/domain/chat/dto/response/ChatMessageDto.java
@@ -1,0 +1,50 @@
+package com.writingboard.server.domain.chat.dto.response;
+
+import com.writingboard.server.domain.chat.document.ChatMessage;
+import com.writingboard.server.domain.chat.enums.MessageType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageDto {
+
+    private String id;
+    private String roomUuid;
+    private Long senderId;
+    private String senderName;
+    private String senderProfileImage;
+    private String content;
+    private MessageType messageType;
+    private Instant timestamp;
+
+    @Builder
+    public ChatMessageDto(String id, String roomUuid, Long senderId, String senderName,
+                          String senderProfileImage, String content,
+                          MessageType messageType, Instant timestamp) {
+        this.id = id;
+        this.roomUuid = roomUuid;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.senderProfileImage = senderProfileImage;
+        this.content = content;
+        this.messageType = messageType;
+        this.timestamp = timestamp;
+    }
+
+    public static ChatMessageDto from(ChatMessage chatMessage) {
+        return ChatMessageDto.builder()
+                .id(chatMessage.getId())
+                .roomUuid(chatMessage.getRoomUuid())
+                .senderId(chatMessage.getSenderId())
+                .senderName(chatMessage.getSenderName())
+                .senderProfileImage(chatMessage.getSenderProfileImage())
+                .content(chatMessage.getContent())
+                .messageType(chatMessage.getMessageType())
+                .timestamp(chatMessage.getTimestamp())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/enums/MessageType.java
+++ b/src/main/java/com/writingboard/server/domain/chat/enums/MessageType.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.chat.enums;
+
+public enum MessageType {
+    TEXT,    // 일반 텍스트 메시지
+    SYSTEM   // 시스템 메시지 (입장/퇴장 등)
+}

--- a/src/main/java/com/writingboard/server/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/chat/exception/ChatErrorCode.java
@@ -1,0 +1,29 @@
+package com.writingboard.server.domain.chat.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode {
+
+    // Message
+    EMPTY_MESSAGE(HttpStatus.BAD_REQUEST, "CHAT_001", "메시지 내용이 비어있습니다"),
+    MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "CHAT_002", "메시지가 너무 깁니다 (최대 2000자)"),
+
+    // Room
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_003", "회의실을 찾을 수 없습니다"),
+    ROOM_CLOSED(HttpStatus.BAD_REQUEST, "CHAT_004", "종료된 회의실에서는 채팅할 수 없습니다"),
+
+    // Participant
+    NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "CHAT_005", "해당 회의실의 참여자가 아닙니다"),
+    NOT_PARTICIPANT_HISTORY(HttpStatus.FORBIDDEN, "CHAT_006", "채팅 기록을 조회할 권한이 없습니다"),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_007", "사용자를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/writingboard/server/domain/chat/exception/ChatException.java
+++ b/src/main/java/com/writingboard/server/domain/chat/exception/ChatException.java
@@ -1,0 +1,19 @@
+package com.writingboard.server.domain.chat.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ChatException extends RuntimeException {
+
+    private final ChatErrorCode errorCode;
+
+    public ChatException(ChatErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ChatException(ChatErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/writingboard/server/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,39 @@
+package com.writingboard.server.domain.chat.repository;
+
+import com.writingboard.server.domain.chat.document.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+
+    /**
+     * 커서 기반 페이징: 특정 시점 이전 메시지 조회 (무한 스크롤)
+     */
+    @Query("{ 'roomUuid': ?0, 'timestamp': { $lt: ?1 } }")
+    List<ChatMessage> findByRoomUuidAndTimestampBefore(
+            String roomUuid,
+            Instant before,
+            Pageable pageable
+    );
+
+    /**
+     * 최신 N개 메시지 조회 (초기 로드)
+     */
+    List<ChatMessage> findByRoomUuidOrderByTimestampDesc(
+            String roomUuid,
+            Pageable pageable
+    );
+
+    /**
+     * 특정 시점 이후 메시지 조회 (재연결 시 동기화)
+     */
+    @Query("{ 'roomUuid': ?0, 'timestamp': { $gt: ?1 } }")
+    List<ChatMessage> findByRoomUuidAndTimestampAfter(
+            String roomUuid,
+            Instant after
+    );
+}

--- a/src/main/java/com/writingboard/server/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/writingboard/server/domain/chat/service/ChatHistoryService.java
@@ -1,0 +1,86 @@
+package com.writingboard.server.domain.chat.service;
+
+import com.writingboard.server.domain.chat.document.ChatMessage;
+import com.writingboard.server.domain.chat.dto.response.ChatHistoryResponse;
+import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
+import com.writingboard.server.domain.chat.exception.ChatErrorCode;
+import com.writingboard.server.domain.chat.exception.ChatException;
+import com.writingboard.server.domain.chat.repository.ChatMessageRepository;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatHistoryService {
+
+    private static final int DEFAULT_LIMIT = 50;
+    private static final int MAX_LIMIT = 100;
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+
+    /**
+     * 채팅 기록 조회 (커서 기반 페이징)
+     * - 진행 중인 회의실: 현재 참여자만 조회 가능
+     * - 종료된 회의실: 참여 이력이 있는 사용자만 조회 가능
+     */
+    public ChatHistoryResponse getMessages(Long memberId, String roomUuid,
+                                            Instant before, Integer limit) {
+        // 1. 회의실 조회
+        Room room = roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.ROOM_NOT_FOUND));
+
+        // 2. 참여 이력 검증 (현재 참여 또는 과거 참여)
+        boolean hasParticipationHistory = participantRepository.findByRoomIdAndMemberId(
+                room.getId(), memberId).isPresent();
+
+        if (!hasParticipationHistory) {
+            throw new ChatException(ChatErrorCode.NOT_PARTICIPANT_HISTORY);
+        }
+
+        // 3. 페이징 설정
+        int actualLimit = resolveLimit(limit);
+        Pageable pageable = PageRequest.of(0, actualLimit, Sort.by(Sort.Direction.DESC, "timestamp"));
+
+        // 4. 메시지 조회
+        List<ChatMessage> messages;
+        if (before != null) {
+            // 커서 기반: before 시점 이전 메시지
+            messages = chatMessageRepository.findByRoomUuidAndTimestampBefore(
+                    roomUuid, before, pageable);
+        } else {
+            // 초기 로드: 최신 메시지
+            messages = chatMessageRepository.findByRoomUuidOrderByTimestampDesc(
+                    roomUuid, pageable);
+        }
+
+        // 5. DTO 변환 및 응답
+        List<ChatMessageDto> messageDtos = messages.stream()
+                .map(ChatMessageDto::from)
+                .toList();
+
+        log.debug("채팅 기록 조회: roomUuid={}, memberId={}, count={}",
+                roomUuid, memberId, messageDtos.size());
+
+        return ChatHistoryResponse.of(messageDtos, actualLimit);
+    }
+
+    private int resolveLimit(Integer limit) {
+        if (limit == null || limit <= 0) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.min(limit, MAX_LIMIT);
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/service/ChatHistoryService.java
+++ b/src/main/java/com/writingboard/server/domain/chat/service/ChatHistoryService.java
@@ -32,9 +32,7 @@ public class ChatHistoryService {
     private final RoomParticipantRepository participantRepository;
 
     /**
-     * 채팅 기록 조회 (커서 기반 페이징)
-     * - 진행 중인 회의실: 현재 참여자만 조회 가능
-     * - 종료된 회의실: 참여 이력이 있는 사용자만 조회 가능
+     * 채팅 기록 조회
      */
     public ChatHistoryResponse getMessages(Long memberId, String roomUuid,
                                             Instant before, Integer limit) {
@@ -42,9 +40,8 @@ public class ChatHistoryService {
         Room room = roomRepository.findByRoomUuid(roomUuid)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.ROOM_NOT_FOUND));
 
-        // 2. 참여 이력 검증 (현재 참여 또는 과거 참여)
-        boolean hasParticipationHistory = participantRepository.findByRoomIdAndMemberId(
-                room.getId(), memberId).isPresent();
+        // 2. 참여 이력 검증
+        boolean hasParticipationHistory = participantRepository.findByRoomIdAndMemberId(room.getId(), memberId).isPresent();
 
         if (!hasParticipationHistory) {
             throw new ChatException(ChatErrorCode.NOT_PARTICIPANT_HISTORY);
@@ -57,11 +54,11 @@ public class ChatHistoryService {
         // 4. 메시지 조회
         List<ChatMessage> messages;
         if (before != null) {
-            // 커서 기반: before 시점 이전 메시지
+            // before 시점 이전 메시지
             messages = chatMessageRepository.findByRoomUuidAndTimestampBefore(
                     roomUuid, before, pageable);
         } else {
-            // 초기 로드: 최신 메시지
+            // 최신 메시지
             messages = chatMessageRepository.findByRoomUuidOrderByTimestampDesc(
                     roomUuid, pageable);
         }

--- a/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisPublisher.java
@@ -23,7 +23,6 @@ public class ChatRedisPublisher {
             log.debug("Redis 메시지 발행: channel={}, messageId={}", channel, message.getId());
         } catch (Exception e) {
             log.error("Redis 메시지 발행 실패: channel={}", channel, e);
-            // MongoDB에 이미 저장되어 있으므로 실패해도 무시
         }
     }
 }

--- a/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisPublisher.java
@@ -1,0 +1,29 @@
+package com.writingboard.server.domain.chat.service;
+
+import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRedisPublisher {
+
+    private static final String CHANNEL_PREFIX = "chat:room:";
+
+    private final RedisTemplate<String, ChatMessageDto> chatRedisTemplate;
+
+    public void publish(String roomUuid, ChatMessageDto message) {
+        String channel = CHANNEL_PREFIX + roomUuid;
+
+        try {
+            chatRedisTemplate.convertAndSend(channel, message);
+            log.debug("Redis 메시지 발행: channel={}, messageId={}", channel, message.getId());
+        } catch (Exception e) {
+            log.error("Redis 메시지 발행 실패: channel={}", channel, e);
+            // MongoDB에 이미 저장되어 있으므로 실패해도 무시
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisSubscriber.java
+++ b/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisSubscriber.java
@@ -30,11 +30,10 @@ public class ChatRedisSubscriber implements MessageListener {
             ChatMessageDto chatMessage = objectMapper.readValue(body, ChatMessageDto.class);
             String roomUuid = extractRoomUuid(channel);
 
-            // 해당 서버 인스턴스의 로컬 구독자에게 전송
             String destination = TOPIC_PREFIX + roomUuid;
-            messagingTemplate.convertAndSend(destination, chatMessage);
+            messagingTemplate.convertAndSend(destination, chatMessage); // 회의실 참여자에게 전송
 
-            log.debug("로컬 구독자에게 메시지 전송: destination={}, messageId={}",
+            log.debug("클라이언트로 메시지 전송: destination={}, messageId={}",
                     destination, chatMessage.getId());
 
         } catch (Exception e) {
@@ -43,7 +42,6 @@ public class ChatRedisSubscriber implements MessageListener {
     }
 
     private String extractRoomUuid(String channel) {
-        // chat:room:{roomUuid} -> roomUuid 추출
         return channel.replace(CHANNEL_PREFIX, "");
     }
 }

--- a/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisSubscriber.java
+++ b/src/main/java/com/writingboard/server/domain/chat/service/ChatRedisSubscriber.java
@@ -1,0 +1,49 @@
+package com.writingboard.server.domain.chat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRedisSubscriber implements MessageListener {
+
+    private static final String CHANNEL_PREFIX = "chat:room:";
+    private static final String TOPIC_PREFIX = "/topic/room/";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String body = new String(message.getBody());
+
+            ChatMessageDto chatMessage = objectMapper.readValue(body, ChatMessageDto.class);
+            String roomUuid = extractRoomUuid(channel);
+
+            // 해당 서버 인스턴스의 로컬 구독자에게 전송
+            String destination = TOPIC_PREFIX + roomUuid;
+            messagingTemplate.convertAndSend(destination, chatMessage);
+
+            log.debug("로컬 구독자에게 메시지 전송: destination={}, messageId={}",
+                    destination, chatMessage.getId());
+
+        } catch (Exception e) {
+            log.error("Redis 메시지 처리 실패", e);
+        }
+    }
+
+    private String extractRoomUuid(String channel) {
+        // chat:room:{roomUuid} -> roomUuid 추출
+        return channel.replace(CHANNEL_PREFIX, "");
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/chat/service/ChatService.java
+++ b/src/main/java/com/writingboard/server/domain/chat/service/ChatService.java
@@ -1,0 +1,98 @@
+package com.writingboard.server.domain.chat.service;
+
+import com.writingboard.server.domain.chat.document.ChatMessage;
+import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
+import com.writingboard.server.domain.chat.exception.ChatErrorCode;
+import com.writingboard.server.domain.chat.exception.ChatException;
+import com.writingboard.server.domain.chat.repository.ChatMessageRepository;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.HtmlUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private static final int MAX_MESSAGE_LENGTH = 2000;
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+    private final MemberRepository memberRepository;
+    private final ChatRedisPublisher chatRedisPublisher;
+
+    public ChatMessageDto sendMessage(Long memberId, String roomUuid, String content) {
+        // 1. 내용 검증
+        validateContent(content);
+
+        // 2. XSS 방지
+        String sanitizedContent = HtmlUtils.htmlEscape(content);
+
+        // 3. 회의실 조회 및 상태 검증
+        Room room = roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.ROOM_NOT_FOUND));
+
+        if (room.getStatus() != RoomStatus.OPEN) {
+            throw new ChatException(ChatErrorCode.ROOM_CLOSED);
+        }
+
+        // 4. 참여자 검증
+        validateParticipant(room.getId(), memberId);
+
+        // 5. 발신자 조회
+        Member sender = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.MEMBER_NOT_FOUND));
+
+        // 6. 메시지 생성 및 저장
+        ChatMessage chatMessage = ChatMessage.createText(roomUuid, sender, sanitizedContent);
+        chatMessageRepository.save(chatMessage);
+
+        // 7. DTO 변환
+        ChatMessageDto messageDto = ChatMessageDto.from(chatMessage);
+
+        // 8. Redis Pub/Sub 발행
+        chatRedisPublisher.publish(roomUuid, messageDto);
+
+        log.debug("메시지 전송 완료: roomUuid={}, senderId={}, messageId={}",
+                roomUuid, memberId, chatMessage.getId());
+
+        return messageDto;
+    }
+
+    public ChatMessageDto sendSystemMessage(String roomUuid, String content) {
+        ChatMessage chatMessage = ChatMessage.createSystem(roomUuid, content);
+        chatMessageRepository.save(chatMessage);
+
+        ChatMessageDto messageDto = ChatMessageDto.from(chatMessage);
+        chatRedisPublisher.publish(roomUuid, messageDto);
+
+        return messageDto;
+    }
+
+    private void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new ChatException(ChatErrorCode.EMPTY_MESSAGE);
+        }
+        if (content.length() > MAX_MESSAGE_LENGTH) {
+            throw new ChatException(ChatErrorCode.MESSAGE_TOO_LONG);
+        }
+    }
+
+    private void validateParticipant(Long roomId, Long memberId) {
+        boolean isParticipant = participantRepository.existsByRoomIdAndMemberIdAndState(
+                roomId, memberId, ParticipantState.JOINED);
+
+        if (!isParticipant) {
+            throw new ChatException(ChatErrorCode.NOT_PARTICIPANT);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
@@ -1,0 +1,52 @@
+package com.writingboard.server.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
+import com.writingboard.server.domain.chat.service.ChatRedisSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisPubSubConfig {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            RedisConnectionFactory redisConnectionFactory,
+            ChatRedisSubscriber chatRedisSubscriber) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+
+        // chat:room:* 패턴의 모든 채널 구독
+        container.addMessageListener(chatRedisSubscriber, new PatternTopic("chat:room:*"));
+
+        return container;
+    }
+
+    @Bean
+    public RedisTemplate<String, ChatMessageDto> chatRedisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, ChatMessageDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        Jackson2JsonRedisSerializer<ChatMessageDto> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, ChatMessageDto.class);
+
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+}

--- a/src/main/java/com/writingboard/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/static/**",
-                                "/error"
+                                "/error",
+                                "/ws-stomp/**" // WebSocket 엔드포인트
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
@@ -1,0 +1,51 @@
+package com.writingboard.server.global.config;
+
+import com.writingboard.server.domain.auth.jwt.JwtProvider;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.global.websocket.JwtHandshakeInterceptor;
+import com.writingboard.server.global.websocket.StompChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtProvider jwtProvider;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 클라이언트 구독 prefix (SimpleBroker 사용)
+        registry.enableSimpleBroker("/topic", "/queue");
+
+        // 클라이언트 발행 prefix -> @MessageMapping 핸들러로 라우팅
+        registry.setApplicationDestinationPrefixes("/app");
+
+        // 개인 메시지용 prefix
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOriginPatterns("*")
+                .addInterceptors(new JwtHandshakeInterceptor(jwtProvider))
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(
+                new StompChannelInterceptor(jwtProvider, roomRepository, participantRepository)
+        );
+    }
+}

--- a/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
@@ -24,13 +24,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        // 클라이언트 구독 prefix (SimpleBroker 사용)
         registry.enableSimpleBroker("/topic", "/queue");
-
-        // 클라이언트 발행 prefix -> @MessageMapping 핸들러로 라우팅
         registry.setApplicationDestinationPrefixes("/app");
-
-        // 개인 메시지용 prefix
+        // 개인 메시지용
         registry.setUserDestinationPrefix("/user");
     }
 

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.writingboard.server.global.exception;
 
+import com.writingboard.server.domain.chat.exception.ChatException;
 import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.member.exception.MemberException;
 import com.writingboard.server.global.common.ErrorResponse;
@@ -17,6 +18,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MeetingException.class)
     public ResponseEntity<ErrorResponse> handleMeetingException(MeetingException e) {
         log.warn("MeetingException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(ChatException.class)
+    public ResponseEntity<ErrorResponse> handleChatException(ChatException e) {
+        log.warn("ChatException: {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));

--- a/src/main/java/com/writingboard/server/global/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/writingboard/server/global/websocket/JwtHandshakeInterceptor.java
@@ -1,0 +1,57 @@
+package com.writingboard.server.global.websocket;
+
+import com.writingboard.server.domain.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request,
+                                   ServerHttpResponse response,
+                                   WebSocketHandler wsHandler,
+                                   Map<String, Object> attributes) {
+        String token = extractToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long memberId = jwtProvider.getMemberIdFromToken(token);
+            attributes.put("memberId", memberId);
+            log.debug("WebSocket 핸드셰이크 성공: memberId={}", memberId);
+            return true;
+        }
+
+        log.warn("WebSocket 핸드셰이크 실패: 유효하지 않은 토큰");
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request,
+                               ServerHttpResponse response,
+                               WebSocketHandler wsHandler,
+                               Exception exception) {
+        // 후처리 없음
+    }
+
+    private String extractToken(ServerHttpRequest request) {
+        String query = request.getURI().getQuery();
+        if (query != null && query.contains("token=")) {
+            String[] params = query.split("&");
+            for (String param : params) {
+                if (param.startsWith("token=")) {
+                    return param.substring(6);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/writingboard/server/global/websocket/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/writingboard/server/global/websocket/JwtHandshakeInterceptor.java
@@ -25,7 +25,7 @@ public class JwtHandshakeInterceptor implements HandshakeInterceptor {
 
         if (token != null && jwtProvider.validateToken(token)) {
             Long memberId = jwtProvider.getMemberIdFromToken(token);
-            attributes.put("memberId", memberId);
+            attributes.put("memberId", memberId); // 세션 저장
             log.debug("WebSocket 핸드셰이크 성공: memberId={}", memberId);
             return true;
         }

--- a/src/main/java/com/writingboard/server/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/com/writingboard/server/global/websocket/StompChannelInterceptor.java
@@ -1,0 +1,112 @@
+package com.writingboard.server.global.websocket;
+
+import com.writingboard.server.domain.auth.jwt.JwtProvider;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+
+@Slf4j
+@RequiredArgsConstructor
+public class StompChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) {
+            return message;
+        }
+
+        StompCommand command = accessor.getCommand();
+
+        if (StompCommand.CONNECT.equals(command)) {
+            handleConnect(accessor);
+        }
+
+        if (StompCommand.SUBSCRIBE.equals(command)) {
+            handleSubscribe(accessor);
+        }
+
+        return message;
+    }
+
+    private void handleConnect(StompHeaderAccessor accessor) {
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            if (jwtProvider.validateToken(token)) {
+                Long memberId = jwtProvider.getMemberIdFromToken(token);
+                accessor.setUser(new StompPrincipal(memberId));
+                log.debug("STOMP CONNECT 성공: memberId={}", memberId);
+            } else {
+                throw new MessagingException("Invalid JWT token");
+            }
+        } else {
+            // 핸드셰이크에서 이미 검증된 경우 세션 속성에서 가져옴
+            Object memberIdAttr = accessor.getSessionAttributes() != null
+                    ? accessor.getSessionAttributes().get("memberId")
+                    : null;
+
+            if (memberIdAttr instanceof Long memberId) {
+                accessor.setUser(new StompPrincipal(memberId));
+                log.debug("STOMP CONNECT (세션): memberId={}", memberId);
+            }
+        }
+    }
+
+    private void handleSubscribe(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+
+        if (destination != null && destination.startsWith("/topic/room/")) {
+            String roomUuid = extractRoomUuid(destination);
+            Long memberId = getMemberId(accessor);
+
+            if (memberId == null) {
+                throw new MessagingException("인증되지 않은 사용자입니다.");
+            }
+
+            if (!isParticipant(roomUuid, memberId)) {
+                log.warn("SUBSCRIBE 거부: memberId={}, roomUuid={}", memberId, roomUuid);
+                throw new MessagingException("해당 회의실의 참여자가 아닙니다.");
+            }
+
+            log.debug("SUBSCRIBE 허용: memberId={}, roomUuid={}", memberId, roomUuid);
+        }
+    }
+
+    private String extractRoomUuid(String destination) {
+        // /topic/room/{roomUuid} 또는 /topic/room/{roomUuid}/system
+        String[] parts = destination.split("/");
+        return parts.length >= 4 ? parts[3] : null;
+    }
+
+    private Long getMemberId(StompHeaderAccessor accessor) {
+        if (accessor.getUser() instanceof StompPrincipal principal) {
+            return principal.getMemberId();
+        }
+        return null;
+    }
+
+    private boolean isParticipant(String roomUuid, Long memberId) {
+        return roomRepository.findByRoomUuid(roomUuid)
+                .map(room -> participantRepository.existsByRoomIdAndMemberIdAndState(
+                        room.getId(), memberId, ParticipantState.JOINED))
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/writingboard/server/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/com/writingboard/server/global/websocket/StompChannelInterceptor.java
@@ -53,18 +53,19 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             if (jwtProvider.validateToken(token)) {
                 Long memberId = jwtProvider.getMemberIdFromToken(token);
                 accessor.setUser(new StompPrincipal(memberId));
+
                 log.debug("STOMP CONNECT 성공: memberId={}", memberId);
             } else {
                 throw new MessagingException("Invalid JWT token");
             }
         } else {
-            // 핸드셰이크에서 이미 검증된 경우 세션 속성에서 가져옴
+            // 핸드셰이크에서 이미 검증된 경우 세션 속성에서 멤버 아이디 가져옴
             Object memberIdAttr = accessor.getSessionAttributes() != null
                     ? accessor.getSessionAttributes().get("memberId")
                     : null;
 
             if (memberIdAttr instanceof Long memberId) {
-                accessor.setUser(new StompPrincipal(memberId));
+                accessor.setUser(new StompPrincipal(memberId)); // @MessageMapping 핸들러에서 Principal로 사용
                 log.debug("STOMP CONNECT (세션): memberId={}", memberId);
             }
         }
@@ -75,13 +76,13 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
         if (destination != null && destination.startsWith("/topic/room/")) {
             String roomUuid = extractRoomUuid(destination);
-            Long memberId = getMemberId(accessor);
+            Long memberId = getMemberId(accessor); // STOMP 헤더에서 멤버 아이디 추출
 
             if (memberId == null) {
                 throw new MessagingException("인증되지 않은 사용자입니다.");
             }
 
-            if (!isParticipant(roomUuid, memberId)) {
+            if (!isParticipant(roomUuid, memberId)) { // 회의실 참여자만 메세지 보내고 받는거 허용
                 log.warn("SUBSCRIBE 거부: memberId={}, roomUuid={}", memberId, roomUuid);
                 throw new MessagingException("해당 회의실의 참여자가 아닙니다.");
             }

--- a/src/main/java/com/writingboard/server/global/websocket/StompPrincipal.java
+++ b/src/main/java/com/writingboard/server/global/websocket/StompPrincipal.java
@@ -1,0 +1,21 @@
+package com.writingboard.server.global.websocket;
+
+import java.security.Principal;
+
+public class StompPrincipal implements Principal {
+
+    private final Long memberId;
+
+    public StompPrincipal(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(memberId);
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,8 @@ spring:
       host: localhost
       port: 6379
       password: ${REDIS_PASSWORD}
+    mongodb:
+      uri: mongodb://${MONGO_USER:root}:${MONGO_PASSWORD}@localhost:27017/writing_db?authSource=admin
 
   datasource:
     url: jdbc:mysql://localhost:3306/writing_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,7 +5,7 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD}
     mongodb:
-      uri: mongodb://${MONGO_USER:root}:${MONGO_PASSWORD}@localhost:27017/writing_db?authSource=admin
+      uri: mongodb://yoon9531:testpasswordadmin1234@localhost:27017/writing_db?authSource=writing_db
 
   datasource:
     url: jdbc:mysql://localhost:3306/writing_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
@@ -33,6 +33,11 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+    com.writingboard.server: DEBUG
+    org.springframework.messaging: DEBUG
+    org.springframework.web.socket: DEBUG
+    org.springframework.data.mongodb: DEBUG
+    org.springframework.data.redis: DEBUG
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
### 개요
Websocket+STOMP로 실시간 채팅 기능 구현. 다중 인스턴스 환경과 어플리케이션 메모리 자원을 고려하여 Redis pub/sub을 활용하여 구현.

### 구현 상세
1. Chat Domain (src/main/java/com/writingboard/server/domain/chat)
`ChatMessage.java` : 채팅 메세지 document

발신자, 내용, 타임스탬프, 메시지 타입 등 채팅 메시지의 구조 정의.
채팅 기록은 NoSQL 데이터베이스(예: MongoDB)에 저장

**Controllers**

`ChatMessageController.java`: WebSocket STOMP 엔드포인트로 들어오는 실시간 채팅 메시지를 처리.
`ChatHistoryController.java`: 과거 채팅 내역을 조회할 수 있는 REST API 엔드포인트를 제공함.

**DTOs & Enums**

ChatMessageRequest, ChatHistoryResponse: 클라이언트와의 데이터 교환을 위한 DTO.
MessageType.java: TALK(대화), ENTER(입장), QUIT(퇴장) 등 메시지 유형을 정의하여 이벤트별로 다르게 처리할 수 있도록 했습니다.

**Services**
`ChatService.java`: 메시지 처리, 저장, 배포를 조정하는 핵심 비즈니스 로직
`ChatHistoryService.java`: 채팅 내역 조회 및 페이징 처리를 담당
`ChatRedisPublisher & ChatRedisSubscriber`: Redis의 Pub/Sub 메커니즘을 활용하여 메시지를 모든 연결된 클라이언트(및 다른 서버 인스턴스)로 전파

2. **Global Configuration** (src/main/java/com/writingboard/server/global/config)
`WebSocketConfig.java`
WebSocket 엔드포인트를 구성하고 STOMP 메시징을 활성화한다.
외부 브로커(Redis)와 내부 인메모리 브로커 설정을 포함.

`RedisPubSubConfig.java`
채팅 메시지 분산을 위한 Redis 연결 팩토리와 메시지 리스너 컨테이너를 설정.
`SecurityConfig.java`
WebSocket 핸드셰이크 및 STOMP 엔드포인트에 대한 접근 허용 설정추가.

3. WebSocket Interceptors (src/main/java/com/writingboard/server/global/websocket)

`JwtHandshakeInterceptor.java`
WebSocket 핸드셰이크 요청을 가로채어 클라이언트의 JWT 토큰(쿼리 파라미터 등)을 검증한다. 인증된 사용자만 연결을 수립할 수 있도록 제한.

`StompChannelInterceptor.java`
STOMP 메시지의 송수신을 가로채어 추가적인 인증/인가 검사, 로깅, 헤더 조작 등의 작업을 수행.

`StompPrincipal.java`
WebSocket 세션 내에서 인증된 사용자를 식별하기 위한 커스텀 Principal 객체