### PR TITLE
feat: WebRTC 시그널링 서버 구현 및 voice 도메인 신설

### DIFF
--- a/src/main/java/com/writingboard/server/domain/voice/controller/VoiceSignalingController.java
+++ b/src/main/java/com/writingboard/server/domain/voice/controller/VoiceSignalingController.java
@@ -1,0 +1,56 @@
+package com.writingboard.server.domain.voice.controller;
+
+import com.writingboard.server.domain.voice.dto.request.VoiceSignalRequest;
+import com.writingboard.server.domain.voice.service.VoiceService;
+import com.writingboard.server.global.websocket.StompPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class VoiceSignalingController {
+
+    private final VoiceService voiceService;
+
+    /**
+     * WebRTC 시그널 전송
+     * Client 전송 -> /app/room/{roomUuid}/voice
+     * Redis Pub/Sub -> /topic/room/{roomUuid}/voice
+     */
+    @MessageMapping("/room/{roomUuid}/voice")
+    public void handleVoiceSignal(
+            @DestinationVariable String roomUuid,
+            @Payload @Valid VoiceSignalRequest request,
+            Principal principal) {
+
+        Long memberId = getMemberId(principal);
+        voiceService.sendSignal(memberId, roomUuid, request);
+    }
+
+    /**
+     * 에러 발생 시 개인 큐로 에러 메시지 전송
+     */
+    @MessageExceptionHandler
+    @SendToUser("/queue/errors")
+    public String handleError(Exception e) {
+        log.error("음성 시그널 처리 중 에러", e);
+        return e.getMessage();
+    }
+
+    private Long getMemberId(Principal principal) {
+        if (principal instanceof StompPrincipal stompPrincipal) {
+            return stompPrincipal.getMemberId();
+        }
+        throw new IllegalStateException("인증되지 않은 사용자입니다.");
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/voice/dto/request/VoiceSignalRequest.java
+++ b/src/main/java/com/writingboard/server/domain/voice/dto/request/VoiceSignalRequest.java
@@ -1,0 +1,22 @@
+package com.writingboard.server.domain.voice.dto.request;
+
+import com.writingboard.server.domain.voice.enums.SignalType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoiceSignalRequest {
+
+    @NotNull(message = "시그널 타입은 필수입니다")
+    private SignalType signalType;
+
+    @NotBlank(message = "시그널 데이터는 필수입니다")
+    @Size(max = 10000, message = "시그널 데이터는 최대 10000자까지 가능합니다")
+    private String data;
+}

--- a/src/main/java/com/writingboard/server/domain/voice/dto/response/VoiceSignalDto.java
+++ b/src/main/java/com/writingboard/server/domain/voice/dto/response/VoiceSignalDto.java
@@ -1,0 +1,43 @@
+package com.writingboard.server.domain.voice.dto.response;
+
+import com.writingboard.server.domain.voice.enums.SignalType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+public class VoiceSignalDto {
+
+    private String roomUuid;
+    private Long senderId;
+    private String senderName;
+    private SignalType signalType;
+    private String data;
+    private Instant timestamp;
+
+    @Builder
+    public VoiceSignalDto(String roomUuid, Long senderId, String senderName,
+                          SignalType signalType, String data, Instant timestamp) {
+        this.roomUuid = roomUuid;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.signalType = signalType;
+        this.data = data;
+        this.timestamp = timestamp;
+    }
+
+    public static VoiceSignalDto of(String roomUuid, Long senderId, String senderName,
+                                    SignalType signalType, String data) {
+        return VoiceSignalDto.builder()
+                .roomUuid(roomUuid)
+                .senderId(senderId)
+                .senderName(senderName)
+                .signalType(signalType)
+                .data(data)
+                .timestamp(Instant.now())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/voice/enums/SignalType.java
+++ b/src/main/java/com/writingboard/server/domain/voice/enums/SignalType.java
@@ -1,0 +1,9 @@
+package com.writingboard.server.domain.voice.enums;
+
+public enum SignalType {
+    OFFER,           // SDP offer from caller
+    ANSWER,          // SDP answer from callee
+    ICE_CANDIDATE,   // ICE candidate for NAT traversal
+    JOIN,            // User joins voice channel
+    LEAVE            // User leaves voice channel
+}

--- a/src/main/java/com/writingboard/server/domain/voice/enums/SignalType.java
+++ b/src/main/java/com/writingboard/server/domain/voice/enums/SignalType.java
@@ -1,9 +1,9 @@
 package com.writingboard.server.domain.voice.enums;
 
 public enum SignalType {
-    OFFER,           // SDP offer from caller
-    ANSWER,          // SDP answer from callee
-    ICE_CANDIDATE,   // ICE candidate for NAT traversal
-    JOIN,            // User joins voice channel
-    LEAVE            // User leaves voice channel
+    OFFER,
+    ANSWER,
+    ICE_CANDIDATE,
+    JOIN,
+    LEAVE
 }

--- a/src/main/java/com/writingboard/server/domain/voice/exception/VoiceErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/voice/exception/VoiceErrorCode.java
@@ -1,0 +1,28 @@
+package com.writingboard.server.domain.voice.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum VoiceErrorCode {
+
+    // Signal
+    INVALID_SIGNAL(HttpStatus.BAD_REQUEST, "VOICE_001", "유효하지 않은 시그널입니다"),
+    SIGNAL_DATA_TOO_LARGE(HttpStatus.BAD_REQUEST, "VOICE_002", "시그널 데이터가 너무 큽니다 (최대 10000자)"),
+
+    // Room
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "VOICE_003", "회의실을 찾을 수 없습니다"),
+    ROOM_CLOSED(HttpStatus.BAD_REQUEST, "VOICE_004", "종료된 회의실에서는 음성 통화를 할 수 없습니다"),
+
+    // Participant
+    NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "VOICE_005", "해당 회의실의 참여자가 아닙니다"),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "VOICE_006", "사용자를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/writingboard/server/domain/voice/exception/VoiceException.java
+++ b/src/main/java/com/writingboard/server/domain/voice/exception/VoiceException.java
@@ -1,0 +1,19 @@
+package com.writingboard.server.domain.voice.exception;
+
+import lombok.Getter;
+
+@Getter
+public class VoiceException extends RuntimeException {
+
+    private final VoiceErrorCode errorCode;
+
+    public VoiceException(VoiceErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public VoiceException(VoiceErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/voice/service/VoiceRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/voice/service/VoiceRedisPublisher.java
@@ -1,0 +1,28 @@
+package com.writingboard.server.domain.voice.service;
+
+import com.writingboard.server.domain.voice.dto.response.VoiceSignalDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VoiceRedisPublisher {
+
+    private static final String CHANNEL_PREFIX = "voice:room:";
+
+    private final RedisTemplate<String, VoiceSignalDto> voiceRedisTemplate;
+
+    public void publish(String roomUuid, VoiceSignalDto signal) {
+        String channel = CHANNEL_PREFIX + roomUuid;
+
+        try {
+            voiceRedisTemplate.convertAndSend(channel, signal);
+            log.debug("Redis 시그널 발행: channel={}, signalType={}", channel, signal.getSignalType());
+        } catch (Exception e) {
+            log.error("Redis 시그널 발행 실패: channel={}", channel, e);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/voice/service/VoiceRedisSubscriber.java
+++ b/src/main/java/com/writingboard/server/domain/voice/service/VoiceRedisSubscriber.java
@@ -1,0 +1,47 @@
+package com.writingboard.server.domain.voice.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.writingboard.server.domain.voice.dto.response.VoiceSignalDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VoiceRedisSubscriber implements MessageListener {
+
+    private static final String CHANNEL_PREFIX = "voice:room:";
+    private static final String TOPIC_PREFIX = "/topic/room/";
+    private static final String VOICE_SUFFIX = "/voice";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String body = new String(message.getBody());
+
+            VoiceSignalDto signal = objectMapper.readValue(body, VoiceSignalDto.class);
+            String roomUuid = extractRoomUuid(channel);
+
+            String destination = TOPIC_PREFIX + roomUuid + VOICE_SUFFIX;
+            messagingTemplate.convertAndSend(destination, signal);
+
+            log.debug("클라이언트로 시그널 전송: destination={}, signalType={}",
+                    destination, signal.getSignalType());
+
+        } catch (Exception e) {
+            log.error("Redis 시그널 처리 실패", e);
+        }
+    }
+
+    private String extractRoomUuid(String channel) {
+        return channel.replace(CHANNEL_PREFIX, "");
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/voice/service/VoiceService.java
+++ b/src/main/java/com/writingboard/server/domain/voice/service/VoiceService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class VoiceService {
 
@@ -32,6 +31,7 @@ public class VoiceService {
     /**
      * WebRTC 시그널 전송
      */
+    @Transactional(readOnly = true)
     public VoiceSignalDto sendSignal(Long memberId, String roomUuid, VoiceSignalRequest request) {
         validateSignalData(request);
 

--- a/src/main/java/com/writingboard/server/domain/voice/service/VoiceService.java
+++ b/src/main/java/com/writingboard/server/domain/voice/service/VoiceService.java
@@ -33,10 +33,8 @@ public class VoiceService {
      * WebRTC 시그널 전송
      */
     public VoiceSignalDto sendSignal(Long memberId, String roomUuid, VoiceSignalRequest request) {
-        // 1. 시그널 데이터 검증
         validateSignalData(request);
 
-        // 2. 회의실 조회 및 상태 검증
         Room room = roomRepository.findByRoomUuid(roomUuid)
                 .orElseThrow(() -> new VoiceException(VoiceErrorCode.ROOM_NOT_FOUND));
 
@@ -44,14 +42,11 @@ public class VoiceService {
             throw new VoiceException(VoiceErrorCode.ROOM_CLOSED);
         }
 
-        // 3. 참여자 검증
         validateParticipant(room.getId(), memberId);
 
-        // 4. 발신자 조회
         Member sender = memberRepository.findById(memberId)
                 .orElseThrow(() -> new VoiceException(VoiceErrorCode.MEMBER_NOT_FOUND));
 
-        // 5. DTO 생성
         VoiceSignalDto signalDto = VoiceSignalDto.of(
                 roomUuid,
                 sender.getId(),
@@ -60,7 +55,6 @@ public class VoiceService {
                 request.getData()
         );
 
-        // 6. Redis Pub/Sub 발행
         voiceRedisPublisher.publish(roomUuid, signalDto);
 
         log.debug("음성 시그널 전송 완료: roomUuid={}, senderId={}, signalType={}",

--- a/src/main/java/com/writingboard/server/domain/voice/service/VoiceService.java
+++ b/src/main/java/com/writingboard/server/domain/voice/service/VoiceService.java
@@ -1,0 +1,89 @@
+package com.writingboard.server.domain.voice.service;
+
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.voice.dto.request.VoiceSignalRequest;
+import com.writingboard.server.domain.voice.dto.response.VoiceSignalDto;
+import com.writingboard.server.domain.voice.exception.VoiceErrorCode;
+import com.writingboard.server.domain.voice.exception.VoiceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class VoiceService {
+
+    private static final int MAX_SIGNAL_DATA_LENGTH = 10000;
+
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+    private final MemberRepository memberRepository;
+    private final VoiceRedisPublisher voiceRedisPublisher;
+
+    /**
+     * WebRTC 시그널 전송
+     */
+    public VoiceSignalDto sendSignal(Long memberId, String roomUuid, VoiceSignalRequest request) {
+        // 1. 시그널 데이터 검증
+        validateSignalData(request);
+
+        // 2. 회의실 조회 및 상태 검증
+        Room room = roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new VoiceException(VoiceErrorCode.ROOM_NOT_FOUND));
+
+        if (room.getStatus() != RoomStatus.OPEN) {
+            throw new VoiceException(VoiceErrorCode.ROOM_CLOSED);
+        }
+
+        // 3. 참여자 검증
+        validateParticipant(room.getId(), memberId);
+
+        // 4. 발신자 조회
+        Member sender = memberRepository.findById(memberId)
+                .orElseThrow(() -> new VoiceException(VoiceErrorCode.MEMBER_NOT_FOUND));
+
+        // 5. DTO 생성
+        VoiceSignalDto signalDto = VoiceSignalDto.of(
+                roomUuid,
+                sender.getId(),
+                sender.getName(),
+                request.getSignalType(),
+                request.getData()
+        );
+
+        // 6. Redis Pub/Sub 발행
+        voiceRedisPublisher.publish(roomUuid, signalDto);
+
+        log.debug("음성 시그널 전송 완료: roomUuid={}, senderId={}, signalType={}",
+                roomUuid, memberId, request.getSignalType());
+
+        return signalDto;
+    }
+
+    private void validateSignalData(VoiceSignalRequest request) {
+        if (request.getData() == null || request.getData().isBlank()) {
+            throw new VoiceException(VoiceErrorCode.INVALID_SIGNAL);
+        }
+        if (request.getData().length() > MAX_SIGNAL_DATA_LENGTH) {
+            throw new VoiceException(VoiceErrorCode.SIGNAL_DATA_TOO_LARGE);
+        }
+    }
+
+    private void validateParticipant(Long roomId, Long memberId) {
+        boolean isParticipant = participantRepository.existsByRoomIdAndMemberIdAndState(
+                roomId, memberId, ParticipantState.JOINED);
+
+        if (!isParticipant) {
+            throw new VoiceException(VoiceErrorCode.NOT_PARTICIPANT);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
 import com.writingboard.server.domain.chat.service.ChatRedisSubscriber;
+import com.writingboard.server.domain.voice.dto.response.VoiceSignalDto;
+import com.writingboard.server.domain.voice.service.VoiceRedisSubscriber;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -19,13 +21,17 @@ public class RedisPubSubConfig {
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory redisConnectionFactory,
-            ChatRedisSubscriber chatRedisSubscriber) {
+            ChatRedisSubscriber chatRedisSubscriber,
+            VoiceRedisSubscriber voiceRedisSubscriber) {
 
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
 
         // chat:room:* 패턴의 모든 채널 구독
         container.addMessageListener(chatRedisSubscriber, new PatternTopic("chat:room:*"));
+
+        // voice:room:* 패턴의 모든 채널 구독
+        container.addMessageListener(voiceRedisSubscriber, new PatternTopic("voice:room:*"));
 
         return container;
     }
@@ -43,6 +49,26 @@ public class RedisPubSubConfig {
 
         Jackson2JsonRedisSerializer<ChatMessageDto> serializer =
                 new Jackson2JsonRedisSerializer<>(objectMapper, ChatMessageDto.class);
+
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, VoiceSignalDto> voiceRedisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, VoiceSignalDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        Jackson2JsonRedisSerializer<VoiceSignalDto> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, VoiceSignalDto.class);
 
         template.setValueSerializer(serializer);
         template.afterPropertiesSet();

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.writingboard.server.domain.auth.exception.AuthException;
 import com.writingboard.server.domain.chat.exception.ChatException;
 import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.member.exception.MemberException;
+import com.writingboard.server.domain.voice.exception.VoiceException;
 import com.writingboard.server.global.common.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +36,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ChatException.class)
     public ResponseEntity<ErrorResponse> handleChatException(ChatException e) {
         log.warn("ChatException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(VoiceException.class)
+    public ResponseEntity<ErrorResponse> handleVoiceException(VoiceException e) {
+        log.warn("VoiceException: {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));


### PR DESCRIPTION
Closes #17 

### 개요
WebRTC P2P 통화를 위한 시그널링 서버 구현
기존 Meeting 도메인과 독립적으로 새로운 Voice 도메인 구축

### 상세
음성통화, 시그널링 메시지 따로 db에 저장 X
Redis Pub/Sub 활용
로컬 html 클라이언트로 방 입장 + 시그널 교환 정상 작동 확인 완료
voice domain 독립적으로 분리, global 코드 수정 최소화
주석 정리

```VoiceSignalingController```
클라이언트가 보내는 /app/room/{id}/voice 요청 받음

```VoiceRedisPublisher & VoiceRedisSubscriber```
Pub: 검증된 메시지를 Redis 서버(voice:room:{uuid})로 올림
Sub: Redis 채널을 구독하고 있다가 모든 유저에게 브로드캐스트
인원 제한 있다는 가정하에 구현

```RedisPubSubConfig```
voice:room:* 리스너 별도로 등록
