### PR TITLE
[FEAT] 팀 관련 기능 추가 및 파일 생성 및 조회 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,5 @@ REDIS_PASSWORD=admin1234
 MONGO_USER=yoon9531
 MONGO_PASSWORD=testpasswordadmin1234
 
-# JWT Secret (32자 이상 아무거나)
+# JWT Secret
 JWT_SECRET=

--- a/erd.mermaid
+++ b/erd.mermaid
@@ -1,0 +1,174 @@
+erDiagram
+  %% 유저 및 팀 조직
+  MEMBER {
+    bigint member_id PK
+    varchar name
+    varchar email
+    varchar password_hash "이메일 로그인용 (소셜은 null)"
+    varchar profile_image_url
+    varchar provider_id "google, kakao etc"
+    varchar status "ACTIVE|DELETED"
+    datetime created_at
+    datetime updated_at
+  }
+
+  TEAM {
+    bigint team_id PK
+    varchar name
+    varchar description
+    varchar team_profile_img_url
+    bigint created_by_member_id FK
+    datetime created_at
+    datetime updated_at
+  }
+
+  TEAM_MEMBER {
+    bigint team_member_id PK
+    bigint team_id FK
+    bigint member_id FK
+    varchar role   "OWNER|ADMIN|MEMBER"
+    varchar status "ACTIVE|PENDING|LEFT"
+    datetime joined_at
+    datetime created_at
+  }
+
+  TEAM_INVITATION {
+    bigint invite_id PK
+    bigint team_id FK
+    bigint inviter_member_id FK
+    varchar type "LINK|USER_SEARCH"
+    varchar invite_token
+    datetime expires_at
+    bigint invitee_member_id FK
+    varchar status
+    datetime created_at
+  }
+
+  %% 개인 관리 파일
+  PERSONAL_ASSET {
+    bigint personal_asset_id PK
+    bigint member_id FK "소유자"
+    varchar name
+    varchar type "PDF|IMAGE"
+    varchar storage_key "S3 경로 (개인 폴더)"
+    bigint size_bytes
+    int total_pages
+    datetime created_at
+    datetime deleted_at
+  }
+  %% 팀 관리 파일
+  TEAM_ASSET {
+    bigint asset_id PK
+    bigint team_id FK
+    bigint uploader_member_id FK
+
+    bigint parent_asset_id FK "이전 버전 ID"
+    bigint origin_personal_asset_id FK "개인 파일에서 가져온 경우 원본 ID"
+    varchar source_type "UPLOADED(팀에직접업로드)|IMPORTED(개인파일가져옴)"
+    varchar type "PDF|IMAGE"
+    varchar name
+    varchar storage_key "S3(R2 등) 경로 (팀 폴더)"
+    int version "default 1"
+    boolean is_latest "최신 버전 여부 (조회 최적화)"
+    int total_pages
+    varchar thumnail_image_url
+
+    datetime created_at
+    datetime deleted_at
+  }
+
+  %% 4. 회의실 (Meeting Room)
+  ROOM {
+    bigint room_id PK
+    bigint team_id FK
+    bigint host_id FK
+    varchar title
+    varchar password_hash
+    varchar status "OPEN|CLOSED"
+    datetime closed_at
+    datetime created_at
+  }
+
+  ROOM_INVITE {
+    bigint invite_id PK
+    bigint room_id FK
+    bigint issued_by_member_id FK
+    varchar invite_type
+    varchar invite_token
+    datetime expires_at
+    int max_uses
+    datetime created_at
+  }
+
+  ROOM_PARTICIPANT {
+    bigint participant_id PK
+    bigint room_id FK
+    bigint member_id FK
+    varchar session_id "웹소켓 세션 id"
+    varchar join_type
+    varchar role "HOST|MODERATOR|VIEWER"
+    varchar state "JOINED|LEFT"
+    datetime joined_at
+    datetime left_at
+  }
+
+  %% 회의실 내 자산 및 필기
+  ROOM_ASSET {
+    bigint room_asset_id PK
+    bigint room_id FK
+    bigint asset_id FK "반드시 TEAM_ASSET을 참조"
+    bigint added_by_member_id FK
+    int current_page_number "현재 공유 중인 페이지"
+    boolean is_active "현재 화면에 띄워진 파일인지"
+    varchar save_policy "OVERWRITE|NEW_COPY"
+    datetime added_at
+  }
+
+  %% 페이지별 필기 데이터
+  CANVAS_PAGE {
+    bigint canvas_page_id PK
+    bigint room_asset_id FK
+    int page_index
+
+    longblob raw_data "PencilKit PKDrawing"
+    datetime last_updated_at
+  }
+
+  %% 스냅샷
+  CANVAS_SNAPSHOT {
+    bigint snapshot_id PK
+    bigint room_asset_id FK
+    int page_index
+    longblob stroke_data "복구용 바이너리 백업"
+    varchar trigger_type "AUTO|MANUAL|ERROR"
+    datetime created_at
+  }
+
+  %% User & Team
+  MEMBER ||--o{ TEAM : "created_by"
+  MEMBER ||--o{ TEAM_MEMBER : "belongs"
+  TEAM ||--o{ TEAM_MEMBER : "has"
+  TEAM ||--o{ TEAM_INVITATION : "has"
+
+  %% Personal Assets
+  MEMBER ||--o{ PERSONAL_ASSET : "owns"
+
+  %% Team Assets (Import Logic)
+  TEAM ||--o{ TEAM_ASSET : "owns"
+  MEMBER ||--o{ TEAM_ASSET : "uploads"
+  PERSONAL_ASSET ||--o{ TEAM_ASSET : "imported_to"
+  TEAM_ASSET ||--o{ TEAM_ASSET : "parent_version"
+
+  %% Room
+  TEAM ||--o{ ROOM : "owns"
+  MEMBER ||--o{ ROOM : "hosts"
+  ROOM ||--o{ ROOM_INVITE : "has"
+  ROOM ||--o{ ROOM_PARTICIPANT : "has"
+  MEMBER ||--o{ ROOM_PARTICIPANT : "joins"
+
+  %% Room Assets & Canvas
+  ROOM ||--o{ ROOM_ASSET : "uses"
+  TEAM_ASSET ||--o{ ROOM_ASSET : "instantiated_as"
+
+  ROOM_ASSET ||--o{ CANVAS_PAGE : "has_pages"
+  ROOM_ASSET ||--o{ CANVAS_SNAPSHOT : "has_backups"

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/InviteLinkRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/InviteLinkRequest.java
@@ -2,7 +2,9 @@ package com.writingboard.server.domain.meeting.dto.request;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
+import lombok.NonNull;
 
 @Data
 public class InviteLinkRequest {
@@ -10,4 +12,8 @@ public class InviteLinkRequest {
     @Min(value = 1, message = "최소 1분 이상")
     @Max(value = 60, message = "최대 60분까지")
     private Integer expiresInMinutes = 5;
+
+    @NonNull
+    @Size(max = 50, message = "이름은 최대 50자까지 가능합니다.")
+    private String name;
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
@@ -31,6 +31,10 @@ public class RoomInvite extends BaseEntity {
     @JoinColumn(name = "issued_by", nullable = false, foreignKey = @ForeignKey(name = "fk_invite_issuer"))
     private Member issuedBy;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "used_by", foreignKey = @ForeignKey(name = "fk_invite_user"))
+    private Member usedBy;
+
     @Column(name = "invite_token", length = 128, nullable = false)
     private String inviteToken;
 
@@ -41,35 +45,25 @@ public class RoomInvite extends BaseEntity {
     @Column(name = "expires_at")
     private Instant expiresAt;
 
-    @Column(name = "used_count", nullable = false)
-    private Integer usedCount = 0;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
     private InviteStatus status = InviteStatus.ACTIVE;
 
-    @Column(name = "revoked_at")
-    private Instant revokedAt;
-
-    @Column(name = "note", length = 255)
-    private String note;
-
-    public static RoomInvite issue(Room room, Member issuedBy, String token, InviteType type,
-                                   Instant expiresAt, String note) {
+    public static RoomInvite issue(Room room, Member issuedBy, Member usedBy, String token, InviteType type,
+                                   Instant expiresAt) {
         RoomInvite i = new RoomInvite();
         i.room = room;
         i.issuedBy = issuedBy;
+        i.usedBy = usedBy;
         i.inviteToken = token;
         i.type = type;
         i.expiresAt = expiresAt;
-        i.usedCount = 0;
         i.status = InviteStatus.ACTIVE;
-        i.note = note;
         return i;
     }
 
     public boolean isUsable() {
-        if (status == InviteStatus.EXPIRED) return false;
+        if (status == InviteStatu.EXPIRED) return false;
         return expiresAt == null || !expiresAt.isBefore(Instant.now());
     }
 
@@ -84,7 +78,7 @@ public class RoomInvite extends BaseEntity {
 
         if (expiresAt != null && expiresAt.isBefore(Instant.now())) {
             this.status = InviteStatus.EXPIRED;
-            this.revokedAt = Instant.now();
+            this.expiresAt = Instant.now();
         }
     }
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
@@ -63,7 +63,7 @@ public class RoomInvite extends BaseEntity {
     }
 
     public boolean isUsable() {
-        if (status == InviteStatu.EXPIRED) return false;
+        if (status == InviteStatus.EXPIRED) return false;
         return expiresAt == null || !expiresAt.isBefore(Instant.now());
     }
 

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomParticipant.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomParticipant.java
@@ -74,5 +74,4 @@ public class RoomParticipant {
     public void heartbeat() {
         this.lastSeenAt = Instant.now();
     }
-
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomInviteService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomInviteService.java
@@ -71,7 +71,7 @@ public class RoomInviteService {
     }
 
     private Member getMemberByUserName(String username) {
-        return memberRepository.findByUsername(username)
+        return memberRepository.findByName(username)
                 .orElseThrow(() -> new MeetingException(ErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomInviteService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomInviteService.java
@@ -44,14 +44,13 @@ public class RoomInviteService {
         validateParticipant(room, memberId);
 
         Member issuer = getMemberById(memberId);
+        Member usedBy = getMemberByUserName(request.getName());
         int expireMinutes = request.getExpiresInMinutes() != null ? request.getExpiresInMinutes() : DEFAULT_EXPIRE_MINUTES;
 
         String token = UUID.randomUUID().toString();
         Instant expiresAt = Instant.now().plus(expireMinutes, ChronoUnit.MINUTES);
 
-        RoomInvite invite = RoomInvite.issue(
-                room, issuer, token, InviteType.LINK, expiresAt, null
-        );
+        RoomInvite invite = RoomInvite.issue(room, issuer, usedBy, token, InviteType.LINK, expiresAt);
 
         // 1. DB 저장
         inviteRepository.save(invite);
@@ -68,6 +67,11 @@ public class RoomInviteService {
 
     private Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MeetingException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Member getMemberByUserName(String username) {
+        return memberRepository.findByUsername(username)
                 .orElseThrow(() -> new MeetingException(ErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/com/writingboard/server/domain/member/entity/Member.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/Member.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE) // create 메서드 사용 유도
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Member extends BaseEntity {
 
     @Id
@@ -41,7 +41,7 @@ public class Member extends BaseEntity {
      */
     public static Member createGuest(String deviceId, String name) {
         Member member = new Member();
-        member.email = "guest-" + deviceId.substring(0, Math.min(8, deviceId.length())) + "@temp.local";
+        member.email = "guest-" + deviceId.substring(0, Math.min(10, deviceId.length())) + "@temp.local";
         member.name = name != null && !name.isBlank() ? name : "Guest-" + deviceId.substring(0, 6).toUpperCase();
         member.providerId = deviceId;
         member.profileImageUrl = null;

--- a/src/main/java/com/writingboard/server/domain/member/entity/Member.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/Member.java
@@ -50,7 +50,7 @@ public class Member extends BaseEntity {
     }
 
     /**
-     * OAuth 사용자 생성 (향후 Apple Sign-In 등)
+     * OAuth 사용자 생성
      */
     public static Member create(String email, String name, String providerId, String profileImageUrl) {
         Member member = new Member();

--- a/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
@@ -8,5 +8,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByProviderId(String providerId);
 
-    Optional<Member> findByUsername (String username);
+    Optional<Member> findByName (String username);
 }

--- a/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
@@ -2,10 +2,11 @@ package com.writingboard.server.domain.member.repository;
 
 import com.writingboard.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByProviderId(String providerId);
+
+    Optional<Member> findByUsername (String username);
 }

--- a/src/main/java/com/writingboard/server/domain/team/controller/InvitationController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/InvitationController.java
@@ -2,6 +2,7 @@ package com.writingboard.server.domain.team.controller;
 
 import com.writingboard.server.domain.team.dto.response.TeamInvitationResponse;
 import com.writingboard.server.domain.team.service.TeamInvitationService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ public class InvitationController {
     private final TeamInvitationService teamInvitationService;
 
     @GetMapping
+    @Operation(summary = "내 대기 중인 팀 초대 조회", description = "현재 인증된 사용자가 받은 대기 중인 팀 초대 목록을 조회한다.")
     public ResponseEntity<List<TeamInvitationResponse>> getMyPendingInvitations(
             @AuthenticationPrincipal Long memberId) {
 
@@ -25,6 +27,7 @@ public class InvitationController {
     }
 
     @PostMapping("/link/{inviteToken}/accept")
+    @Operation(summary = "팀 링크 초대 수락", description = "초대 링크 토큰을 사용하여 팀 초대를 수락한다.")
     public ResponseEntity<Void> acceptLinkInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable String inviteToken) {
@@ -34,6 +37,7 @@ public class InvitationController {
     }
 
     @PostMapping("/{invitationId}/accept")
+    @Operation(summary = "직접 초대 수락", description = "토큰이 아닌 어플리케이션 내에서 직접 받은 팀 초대를 수락한다.")
     public ResponseEntity<Void> acceptDirectInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long invitationId) {
@@ -43,6 +47,7 @@ public class InvitationController {
     }
 
     @PostMapping("/{invitationId}/reject")
+    @Operation(summary = "팀 초대 거절", description = "받은 팀 초대를 거절한다.")
     public ResponseEntity<Void> rejectInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long invitationId) {

--- a/src/main/java/com/writingboard/server/domain/team/controller/InvitationController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/InvitationController.java
@@ -1,0 +1,48 @@
+package com.writingboard.server.domain.team.controller;
+
+import com.writingboard.server.domain.team.dto.response.TeamInvitationResponse;
+import com.writingboard.server.domain.team.service.TeamInvitationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/invitations")
+@RequiredArgsConstructor
+public class InvitationController {
+
+    private final TeamInvitationService teamInvitationService;
+
+    @GetMapping
+    public ResponseEntity<List<TeamInvitationResponse>> getMyPendingInvitations(
+            @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(teamInvitationService.getMyPendingInvitations(memberId));
+    }
+
+    @PostMapping("/link/{inviteToken}/accept")
+    public ResponseEntity<Void> acceptLinkInvitation(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String inviteToken) {
+        teamInvitationService.acceptLinkInvitation(memberId, inviteToken);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{invitationId}/accept")
+    public ResponseEntity<Void> acceptDirectInvitation(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long invitationId) {
+        teamInvitationService.acceptDirectInvitation(memberId, invitationId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{invitationId}/reject")
+    public ResponseEntity<Void> rejectInvitation(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long invitationId) {
+        teamInvitationService.rejectInvitation(memberId, invitationId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/controller/InvitationController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/InvitationController.java
@@ -19,13 +19,16 @@ public class InvitationController {
     @GetMapping
     public ResponseEntity<List<TeamInvitationResponse>> getMyPendingInvitations(
             @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(teamInvitationService.getMyPendingInvitations(memberId));
+
+        List<TeamInvitationResponse> myPendingInvitations = teamInvitationService.getMyPendingInvitations(memberId);
+        return ResponseEntity.ok(myPendingInvitations);
     }
 
     @PostMapping("/link/{inviteToken}/accept")
     public ResponseEntity<Void> acceptLinkInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable String inviteToken) {
+
         teamInvitationService.acceptLinkInvitation(memberId, inviteToken);
         return ResponseEntity.ok().build();
     }
@@ -34,6 +37,7 @@ public class InvitationController {
     public ResponseEntity<Void> acceptDirectInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long invitationId) {
+
         teamInvitationService.acceptDirectInvitation(memberId, invitationId);
         return ResponseEntity.ok().build();
     }
@@ -42,6 +46,7 @@ public class InvitationController {
     public ResponseEntity<Void> rejectInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long invitationId) {
+
         teamInvitationService.rejectInvitation(memberId, invitationId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamAssetController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamAssetController.java
@@ -5,6 +5,7 @@ import com.writingboard.server.domain.team.dto.request.AssetUpdateRequest;
 import com.writingboard.server.domain.team.dto.response.AssetListResponse;
 import com.writingboard.server.domain.team.dto.response.AssetResponse;
 import com.writingboard.server.domain.team.service.TeamAssetService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +26,7 @@ public class TeamAssetController {
     private final TeamAssetService teamAssetService;
 
     @PostMapping
+    @Operation(summary = "팀 파일 저장", description = "팀 자료실 내에 파일을 저장한다.")
     public ResponseEntity<AssetResponse> createAsset(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -35,6 +37,7 @@ public class TeamAssetController {
     }
 
     @GetMapping
+    @Operation(summary = "팀 파일 목록 조회", description = "팀 자료실 내에 저장된 파일들의 목록을 조회한다.")
     public ResponseEntity<AssetListResponse> getAssets(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -45,6 +48,7 @@ public class TeamAssetController {
     }
 
     @GetMapping("/{assetId}")
+    @Operation(summary = "팀 파일 상세 조회", description = "팀 자료실 내에 저장된 특정 파일의 상세 정보를 조회한다.")
     public ResponseEntity<AssetResponse> getAsset(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -55,6 +59,7 @@ public class TeamAssetController {
     }
 
     @GetMapping("/{assetId}/versions")
+    @Operation(summary = "팀 파일 버전 히스토리 조회", description = "팀 자료실 내에 저장된 특정 파일의 버전 히스토리를 조회한다.")
     public ResponseEntity<List<AssetResponse>> getVersionHistory(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -65,6 +70,7 @@ public class TeamAssetController {
     }
 
     @PatchMapping("/{assetId}")
+    @Operation(summary = "팀 파일 정보 수정", description = "팀 자료실 내에 저장된 특정 파일의 정보를 수정한다.")
     public ResponseEntity<AssetResponse> updateAsset(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -76,6 +82,7 @@ public class TeamAssetController {
     }
 
     @DeleteMapping("/{assetId}")
+    @Operation(summary = "팀 파일 삭제", description = "팀 자료실 내에 저장된 특정 파일을 삭제(Soft delete)한다.(OWNER, ADMIN 권한 필요)")
     public ResponseEntity<Void> deleteAsset(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -86,6 +93,7 @@ public class TeamAssetController {
     }
 
     @PostMapping("/{assetId}/versions")
+    @Operation(summary = "팀 파일 새 버전 생성", description = "팀 자료실 내에 저장된 특정 파일의 새 버전을 생성한다.")
     public ResponseEntity<AssetResponse> createNewVersion(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamAssetController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamAssetController.java
@@ -1,0 +1,97 @@
+package com.writingboard.server.domain.team.controller;
+
+import com.writingboard.server.domain.team.dto.request.AssetCreateRequest;
+import com.writingboard.server.domain.team.dto.request.AssetUpdateRequest;
+import com.writingboard.server.domain.team.dto.response.AssetListResponse;
+import com.writingboard.server.domain.team.dto.response.AssetResponse;
+import com.writingboard.server.domain.team.service.TeamAssetService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/teams/{teamId}/assets")
+@RequiredArgsConstructor
+public class TeamAssetController {
+
+    private final TeamAssetService teamAssetService;
+
+    @PostMapping
+    public ResponseEntity<AssetResponse> createAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestBody @Valid AssetCreateRequest request) {
+
+        AssetResponse response = teamAssetService.createAsset(memberId, teamId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<AssetListResponse> getAssets(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        AssetListResponse response = teamAssetService.getAssets(memberId, teamId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{assetId}")
+    public ResponseEntity<AssetResponse> getAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long assetId) {
+
+        AssetResponse response = teamAssetService.getAsset(memberId, teamId, assetId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{assetId}/versions")
+    public ResponseEntity<List<AssetResponse>> getVersionHistory(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long assetId) {
+
+        List<AssetResponse> response = teamAssetService.getVersionHistory(memberId, teamId, assetId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{assetId}")
+    public ResponseEntity<AssetResponse> updateAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long assetId,
+            @RequestBody @Valid AssetUpdateRequest request) {
+
+        AssetResponse response = teamAssetService.updateAsset(memberId, teamId, assetId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{assetId}")
+    public ResponseEntity<Void> deleteAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long assetId) {
+
+        teamAssetService.deleteAsset(memberId, teamId, assetId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{assetId}/versions")
+    public ResponseEntity<AssetResponse> createNewVersion(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long assetId) {
+
+        AssetResponse response = teamAssetService.createNewVersion(memberId, teamId, assetId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamController.java
@@ -5,6 +5,7 @@ import com.writingboard.server.domain.team.dto.request.TeamUpdateRequest;
 import com.writingboard.server.domain.team.dto.response.TeamResponse;
 import com.writingboard.server.domain.team.dto.response.TeamSummaryResponse;
 import com.writingboard.server.domain.team.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,7 @@ public class TeamController {
     private final TeamService teamService;
 
     @PostMapping
+    @Operation(summary = "새로운 팀 생성", description = "새로운 팀을 생성하고 생성자의 권한은 OWNER가 된다.")
     public ResponseEntity<TeamResponse> createTeam(
             @AuthenticationPrincipal Long memberId,
             @RequestBody @Valid TeamCreateRequest request) {
@@ -31,6 +33,7 @@ public class TeamController {
     }
 
     @GetMapping
+    @Operation(summary = "내가 속한 팀 목록 조회", description = "현재 인증된 사용자가 속한 모든 팀의 요약 정보를 조회한다.")
     public ResponseEntity<List<TeamSummaryResponse>> getMyTeams(
             @AuthenticationPrincipal Long memberId) {
 
@@ -39,6 +42,7 @@ public class TeamController {
     }
 
     @GetMapping("/{teamId}")
+    @Operation(summary = "팀 상세 정보 조회")
     public ResponseEntity<TeamResponse> getTeam(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {
@@ -48,6 +52,7 @@ public class TeamController {
     }
 
     @PatchMapping("/{teamId}")
+    @Operation(summary = "팀 정보 수정", description = "팀의 이름, 설명, 프로필 이미지를 수정")
     public ResponseEntity<TeamResponse> updateTeam(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -58,6 +63,7 @@ public class TeamController {
     }
 
     @DeleteMapping("/{teamId}")
+    @Operation(summary = "팀 삭제", description = "팀을 삭제한다. 팀의 OWNER만 삭제할 수 있다.")
     public ResponseEntity<Void> deleteTeam(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamController.java
@@ -25,21 +25,26 @@ public class TeamController {
     public ResponseEntity<TeamResponse> createTeam(
             @AuthenticationPrincipal Long memberId,
             @RequestBody @Valid TeamCreateRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(teamService.createTeam(memberId, request));
+
+        TeamResponse team = teamService.createTeam(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(team);
     }
 
     @GetMapping
     public ResponseEntity<List<TeamSummaryResponse>> getMyTeams(
             @AuthenticationPrincipal Long memberId) {
-        return ResponseEntity.ok(teamService.getMyTeams(memberId));
+
+        List<TeamSummaryResponse> teams = teamService.getMyTeams(memberId);
+        return ResponseEntity.ok(teams);
     }
 
     @GetMapping("/{teamId}")
     public ResponseEntity<TeamResponse> getTeam(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {
-        return ResponseEntity.ok(teamService.getTeam(memberId, teamId));
+
+        TeamResponse team = teamService.getTeam(memberId, teamId);
+        return ResponseEntity.ok(team);
     }
 
     @PatchMapping("/{teamId}")
@@ -47,7 +52,9 @@ public class TeamController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
             @RequestBody @Valid TeamUpdateRequest request) {
-        return ResponseEntity.ok(teamService.updateTeam(memberId, teamId, request));
+
+        TeamResponse team = teamService.updateTeam(memberId, teamId, request);
+        return ResponseEntity.ok(team);
     }
 
     @DeleteMapping("/{teamId}")

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamController.java
@@ -1,0 +1,60 @@
+package com.writingboard.server.domain.team.controller;
+
+import com.writingboard.server.domain.team.dto.request.TeamCreateRequest;
+import com.writingboard.server.domain.team.dto.request.TeamUpdateRequest;
+import com.writingboard.server.domain.team.dto.response.TeamResponse;
+import com.writingboard.server.domain.team.dto.response.TeamSummaryResponse;
+import com.writingboard.server.domain.team.service.TeamService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @PostMapping
+    public ResponseEntity<TeamResponse> createTeam(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid TeamCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(teamService.createTeam(memberId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamSummaryResponse>> getMyTeams(
+            @AuthenticationPrincipal Long memberId) {
+        return ResponseEntity.ok(teamService.getMyTeams(memberId));
+    }
+
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamResponse> getTeam(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId) {
+        return ResponseEntity.ok(teamService.getTeam(memberId, teamId));
+    }
+
+    @PatchMapping("/{teamId}")
+    public ResponseEntity<TeamResponse> updateTeam(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestBody @Valid TeamUpdateRequest request) {
+        return ResponseEntity.ok(teamService.updateTeam(memberId, teamId, request));
+    }
+
+    @DeleteMapping("/{teamId}")
+    public ResponseEntity<Void> deleteTeam(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId) {
+        teamService.deleteTeam(memberId, teamId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamInvitationController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamInvitationController.java
@@ -5,6 +5,7 @@ import com.writingboard.server.domain.team.dto.request.TeamInviteLinkRequest;
 import com.writingboard.server.domain.team.dto.response.TeamInvitationResponse;
 import com.writingboard.server.domain.team.dto.response.TeamInviteLinkResponse;
 import com.writingboard.server.domain.team.service.TeamInvitationService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,7 @@ public class TeamInvitationController {
     private final TeamInvitationService teamInvitationService;
 
     @PostMapping("/link")
+    @Operation(summary = "팀 링크 초대 생성", description = "팀 링크 초대를 생성하여 초대 링크를 발급한다.")
     public ResponseEntity<TeamInviteLinkResponse> createLinkInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -32,6 +34,7 @@ public class TeamInvitationController {
     }
 
     @PostMapping("/direct")
+    @Operation(summary = "직접 초대 생성", description = "어플리케이션 내에서 직접 팀 초대를 생성한다.")
     public ResponseEntity<TeamInvitationResponse> createDirectInvitation(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -42,6 +45,7 @@ public class TeamInvitationController {
     }
 
     @GetMapping
+    @Operation(summary = "팀 초대 목록 조회", description = "특정 팀에 대한 모든 팀 초대 목록을 조회한다.")
     public ResponseEntity<List<TeamInvitationResponse>> getTeamInvitations(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamInvitationController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamInvitationController.java
@@ -26,8 +26,9 @@ public class TeamInvitationController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
             @RequestBody(required = false) @Valid TeamInviteLinkRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(teamInvitationService.createLinkInvitation(memberId, teamId, request));
+
+        TeamInviteLinkResponse linkInvitation = teamInvitationService.createLinkInvitation(memberId, teamId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(linkInvitation);
     }
 
     @PostMapping("/direct")
@@ -35,14 +36,17 @@ public class TeamInvitationController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
             @RequestBody @Valid DirectInviteRequest request) {
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(teamInvitationService.createDirectInvitation(memberId, teamId, request));
+
+        TeamInvitationResponse directInvitation = teamInvitationService.createDirectInvitation(memberId, teamId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(directInvitation);
     }
 
     @GetMapping
     public ResponseEntity<List<TeamInvitationResponse>> getTeamInvitations(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {
-        return ResponseEntity.ok(teamInvitationService.getTeamInvitations(memberId, teamId));
+
+        List<TeamInvitationResponse> invitations = teamInvitationService.getTeamInvitations(memberId, teamId);
+        return ResponseEntity.ok(invitations);
     }
 }

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamInvitationController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamInvitationController.java
@@ -1,0 +1,48 @@
+package com.writingboard.server.domain.team.controller;
+
+import com.writingboard.server.domain.team.dto.request.DirectInviteRequest;
+import com.writingboard.server.domain.team.dto.request.TeamInviteLinkRequest;
+import com.writingboard.server.domain.team.dto.response.TeamInvitationResponse;
+import com.writingboard.server.domain.team.dto.response.TeamInviteLinkResponse;
+import com.writingboard.server.domain.team.service.TeamInvitationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/teams/{teamId}/invitations")
+@RequiredArgsConstructor
+public class TeamInvitationController {
+
+    private final TeamInvitationService teamInvitationService;
+
+    @PostMapping("/link")
+    public ResponseEntity<TeamInviteLinkResponse> createLinkInvitation(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestBody(required = false) @Valid TeamInviteLinkRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(teamInvitationService.createLinkInvitation(memberId, teamId, request));
+    }
+
+    @PostMapping("/direct")
+    public ResponseEntity<TeamInvitationResponse> createDirectInvitation(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestBody @Valid DirectInviteRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(teamInvitationService.createDirectInvitation(memberId, teamId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamInvitationResponse>> getTeamInvitations(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId) {
+        return ResponseEntity.ok(teamInvitationService.getTeamInvitations(memberId, teamId));
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
@@ -3,6 +3,7 @@ package com.writingboard.server.domain.team.controller;
 import com.writingboard.server.domain.team.dto.request.RoleChangeRequest;
 import com.writingboard.server.domain.team.dto.response.TeamMemberResponse;
 import com.writingboard.server.domain.team.service.TeamMemberService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ public class TeamMemberController {
     private final TeamMemberService teamMemberService;
 
     @GetMapping
+    @Operation(summary = "팀 멤버 목록 조회", description = "특정 팀에 속한 모든 멤버의 목록을 조회한다.")
     public ResponseEntity<List<TeamMemberResponse>> getTeamMembers(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {
@@ -28,6 +30,7 @@ public class TeamMemberController {
     }
 
     @DeleteMapping("/me")
+    @Operation(summary = "팀 탈퇴", description = "현재 인증된 사용자가 특정 팀에서 탈퇴한다.")
     public ResponseEntity<Void> leaveTeam(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {
@@ -37,6 +40,7 @@ public class TeamMemberController {
     }
 
     @DeleteMapping("/{targetMemberId}")
+    @Operation(summary = "팀 멤버 강제 탈퇴", description = "특정 팀 멤버를 팀에서 강제로 탈퇴시킨다.")
     public ResponseEntity<Void> kickMember(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
@@ -47,6 +51,7 @@ public class TeamMemberController {
     }
 
     @PatchMapping("/{targetMemberId}/role")
+    @Operation(summary = "팀 멤버 역할 변경", description = "특정 팀 멤버의 역할을 변경한다.")
     public ResponseEntity<TeamMemberResponse> changeRole(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
@@ -1,0 +1,53 @@
+package com.writingboard.server.domain.team.controller;
+
+import com.writingboard.server.domain.team.dto.request.RoleChangeRequest;
+import com.writingboard.server.domain.team.dto.response.TeamMemberResponse;
+import com.writingboard.server.domain.team.service.TeamMemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/teams/{teamId}/members")
+@RequiredArgsConstructor
+public class TeamMemberController {
+
+    private final TeamMemberService teamMemberService;
+
+    @GetMapping
+    public ResponseEntity<List<TeamMemberResponse>> getTeamMembers(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId) {
+        return ResponseEntity.ok(teamMemberService.getTeamMembers(memberId, teamId));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> leaveTeam(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId) {
+        teamMemberService.leaveTeam(memberId, teamId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{targetMemberId}")
+    public ResponseEntity<Void> kickMember(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long targetMemberId) {
+        teamMemberService.kickMember(memberId, teamId, targetMemberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{targetMemberId}/role")
+    public ResponseEntity<TeamMemberResponse> changeRole(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long targetMemberId,
+            @RequestBody @Valid RoleChangeRequest request) {
+        return ResponseEntity.ok(teamMemberService.changeRole(memberId, teamId, targetMemberId, request));
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
@@ -22,13 +22,16 @@ public class TeamMemberController {
     public ResponseEntity<List<TeamMemberResponse>> getTeamMembers(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {
-        return ResponseEntity.ok(teamMemberService.getTeamMembers(memberId, teamId));
+
+        List<TeamMemberResponse> teamMembers = teamMemberService.getTeamMembers(teamId, memberId);
+        return ResponseEntity.ok(teamMembers);
     }
 
     @DeleteMapping("/me")
     public ResponseEntity<Void> leaveTeam(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId) {
+
         teamMemberService.leaveTeam(memberId, teamId);
         return ResponseEntity.noContent().build();
     }
@@ -38,6 +41,7 @@ public class TeamMemberController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long teamId,
             @PathVariable Long targetMemberId) {
+
         teamMemberService.kickMember(memberId, teamId, targetMemberId);
         return ResponseEntity.noContent().build();
     }
@@ -48,6 +52,8 @@ public class TeamMemberController {
             @PathVariable Long teamId,
             @PathVariable Long targetMemberId,
             @RequestBody @Valid RoleChangeRequest request) {
-        return ResponseEntity.ok(teamMemberService.changeRole(memberId, teamId, targetMemberId, request));
+
+        TeamMemberResponse updatedMember = teamMemberService.changeRole(memberId, teamId, targetMemberId, request);
+        return ResponseEntity.ok(updatedMember);
     }
 }

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/AssetCreateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/AssetCreateRequest.java
@@ -1,0 +1,23 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import com.writingboard.server.domain.team.entity.enums.AssetSourceType;
+import com.writingboard.server.domain.team.entity.enums.AssetType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class AssetCreateRequest {
+
+    @NotNull(message = "자산 타입은 필수입니다")
+    private AssetType type;
+
+    @NotBlank(message = "자산 이름은 필수입니다")
+    @Size(max = 255, message = "자산 이름은 255자 이내여야 합니다")
+    private String name;
+
+    private AssetSourceType sourceType = AssetSourceType.UPLOADED;
+
+    private Long originPersonalAssetId;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/AssetCreateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/AssetCreateRequest.java
@@ -10,11 +10,11 @@ import lombok.Data;
 @Data
 public class AssetCreateRequest {
 
-    @NotNull(message = "자산 타입은 필수입니다")
+    @NotNull(message = "파일 타입은 필수입니다")
     private AssetType type;
 
-    @NotBlank(message = "자산 이름은 필수입니다")
-    @Size(max = 255, message = "자산 이름은 255자 이내여야 합니다")
+    @NotBlank(message = "파일 이름은 필수입니다")
+    @Size(max = 255, message = "파일 이름은 255자 이내여야 합니다")
     private String name;
 
     private AssetSourceType sourceType = AssetSourceType.UPLOADED;

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/AssetUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/AssetUpdateRequest.java
@@ -6,6 +6,6 @@ import lombok.Data;
 @Data
 public class AssetUpdateRequest {
 
-    @Size(max = 255, message = "자산 이름은 255자 이내여야 합니다")
+    @Size(max = 255, message = "파일 이름은 255자 이내여야 합니다")
     private String name;
 }

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/AssetUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/AssetUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class AssetUpdateRequest {
+
+    @Size(max = 255, message = "자산 이름은 255자 이내여야 합니다")
+    private String name;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/DirectInviteRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/DirectInviteRequest.java
@@ -1,0 +1,11 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import lombok.Data;
+
+@Data
+public class DirectInviteRequest {
+
+    private Long memberId;
+
+    private String memberName;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/DirectInviteRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/DirectInviteRequest.java
@@ -6,6 +6,5 @@ import lombok.Data;
 public class DirectInviteRequest {
 
     private Long memberId;
-
     private String memberName;
 }

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/RoleChangeRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/RoleChangeRequest.java
@@ -1,0 +1,12 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class RoleChangeRequest {
+
+    @NotNull(message = "변경할 역할은 필수입니다")
+    private TeamRole newRole;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/TeamCreateRequest.java
@@ -1,0 +1,22 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TeamCreateRequest {
+
+    @NotBlank(message = "팀 이름은 필수입니다")
+    @Size(max = 100, message = "팀 이름은 100자 이내여야 합니다")
+    private String name;
+
+    @Size(max = 500, message = "팀 설명은 500자 이내여야 합니다")
+    private String description;
+
+    private List<Long> memberIds;
+
+    private List<String> memberNames;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/TeamInviteLinkRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/TeamInviteLinkRequest.java
@@ -1,0 +1,13 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+
+@Data
+public class TeamInviteLinkRequest {
+
+    @Min(value = 1, message = "최소 1분 이상이어야 합니다")
+    @Max(value = 10080, message = "최대 7일(10080분)까지 가능합니다")
+    private Integer expiresInMinutes = 60;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/TeamUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/TeamUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class TeamUpdateRequest {
+
+    @Size(max = 100, message = "팀 이름은 100자 이내여야 합니다")
+    private String name;
+
+    @Size(max = 500, message = "팀 설명은 500자 이내여야 합니다")
+    private String description;
+
+    private String teamProfileImgUrl;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/AssetListResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/AssetListResponse.java
@@ -1,0 +1,32 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+@Builder
+public class AssetListResponse {
+
+    private List<AssetResponse> assets;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean hasNext;
+    private boolean hasPrevious;
+
+    public static AssetListResponse of(Page<AssetResponse> assetPage) {
+        return AssetListResponse.builder()
+                .assets(assetPage.getContent())
+                .page(assetPage.getNumber())
+                .size(assetPage.getSize())
+                .totalElements(assetPage.getTotalElements())
+                .totalPages(assetPage.getTotalPages())
+                .hasNext(assetPage.hasNext())
+                .hasPrevious(assetPage.hasPrevious())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/AssetResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/AssetResponse.java
@@ -1,0 +1,64 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.TeamAsset;
+import com.writingboard.server.domain.team.entity.enums.AssetSourceType;
+import com.writingboard.server.domain.team.entity.enums.AssetType;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class AssetResponse {
+
+    private Long assetId;
+    private Long teamId;
+    private AssetType type;
+    private String name;
+    private AssetSourceType sourceType;
+    private Long originPersonalAssetId;
+    private Integer version;
+    private Boolean isLatest;
+    private Long parentAssetId;
+    private String storageKey;
+    private Integer totalPages;
+    private String thumbnailImageUrl;
+    private UploaderInfo uploader;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public static AssetResponse of(TeamAsset asset) {
+        return AssetResponse.builder()
+                .assetId(asset.getId())
+                .teamId(asset.getTeam().getId())
+                .type(asset.getType())
+                .name(asset.getName())
+                .sourceType(asset.getSourceType())
+                .originPersonalAssetId(asset.getOriginPersonalAssetId())
+                .version(asset.getVersion())
+                .isLatest(asset.getIsLatest())
+                .parentAssetId(asset.getParentAsset() != null ? asset.getParentAsset().getId() : null)
+                .storageKey(asset.getStorageKey())
+                .totalPages(asset.getTotalPages())
+                .thumbnailImageUrl(asset.getThumbnailImageUrl())
+                .uploader(UploaderInfo.of(asset))
+                .createdAt(asset.getCreatedAt())
+                .updatedAt(asset.getUpdatedAt())
+                .build();
+    }
+
+    @Data
+    @Builder
+    public static class UploaderInfo {
+        private Long memberId;
+        private String name;
+
+        public static UploaderInfo of(TeamAsset asset) {
+            return UploaderInfo.builder()
+                    .memberId(asset.getUploader().getId())
+                    .name(asset.getUploader().getName())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/TeamInvitationResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/TeamInvitationResponse.java
@@ -1,0 +1,36 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.TeamInvitation;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class TeamInvitationResponse {
+
+    private Long invitationId;
+    private Long teamId;
+    private String teamName;
+    private String inviterName;
+    private String inviteeName;
+    private String type;
+    private String status;
+    private Instant expiresAt;
+    private Instant createdAt;
+
+    public static TeamInvitationResponse of(TeamInvitation invitation) {
+        return TeamInvitationResponse.builder()
+                .invitationId(invitation.getId())
+                .teamId(invitation.getTeam().getId())
+                .teamName(invitation.getTeam().getName())
+                .inviterName(invitation.getInviter().getName())
+                .inviteeName(invitation.getInvitee() != null ? invitation.getInvitee().getName() : null)
+                .type(invitation.getType().name())
+                .status(invitation.getStatus().name())
+                .expiresAt(invitation.getExpiresAt())
+                .createdAt(invitation.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/TeamInviteLinkResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/TeamInviteLinkResponse.java
@@ -1,0 +1,26 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.TeamInvitation;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class TeamInviteLinkResponse {
+
+    private Long invitationId;
+    private String inviteToken;
+    private String inviteUrl;
+    private Instant expiresAt;
+
+    public static TeamInviteLinkResponse of(TeamInvitation invitation) {
+        return TeamInviteLinkResponse.builder()
+                .invitationId(invitation.getId())
+                .inviteToken(invitation.getInviteToken())
+                .inviteUrl("/api/teams/join/" + invitation.getInviteToken())
+                .expiresAt(invitation.getExpiresAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/TeamMemberResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/TeamMemberResponse.java
@@ -1,0 +1,34 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.TeamMember;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class TeamMemberResponse {
+
+    private Long teamMemberId;
+    private Long memberId;
+    private String name;
+    private String email;
+    private String profileImageUrl;
+    private String role;
+    private String status;
+    private Instant joinedAt;
+
+    public static TeamMemberResponse of(TeamMember teamMember) {
+        return TeamMemberResponse.builder()
+                .teamMemberId(teamMember.getId())
+                .memberId(teamMember.getMember().getId())
+                .name(teamMember.getMember().getName())
+                .email(teamMember.getMember().getEmail())
+                .profileImageUrl(teamMember.getMember().getProfileImageUrl())
+                .role(teamMember.getRole().name())
+                .status(teamMember.getStatus().name())
+                .joinedAt(teamMember.getJoinedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/TeamResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/TeamResponse.java
@@ -1,0 +1,68 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamMember;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@Builder
+public class TeamResponse {
+
+    private Long teamId;
+    private String name;
+    private String description;
+    private String teamProfileImgUrl;
+    private CreatorInfo createdBy;
+    private List<TeamMemberResponse> members;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public static TeamResponse of(Team team, List<TeamMember> members) {
+        return TeamResponse.builder()
+                .teamId(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .teamProfileImgUrl(team.getTeamProfileImgUrl())
+                .createdBy(CreatorInfo.of(team.getCreatedBy()))
+                .members(members.stream()
+                        .map(TeamMemberResponse::of)
+                        .toList())
+                .createdAt(team.getCreatedAt())
+                .updatedAt(team.getUpdatedAt())
+                .build();
+    }
+
+    public static TeamResponse ofSimple(Team team) {
+        return TeamResponse.builder()
+                .teamId(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .teamProfileImgUrl(team.getTeamProfileImgUrl())
+                .createdBy(CreatorInfo.of(team.getCreatedBy()))
+                .members(null)
+                .createdAt(team.getCreatedAt())
+                .updatedAt(team.getUpdatedAt())
+                .build();
+    }
+
+    @Data
+    @Builder
+    public static class CreatorInfo {
+        private Long memberId;
+        private String name;
+        private String email;
+
+        public static CreatorInfo of(Member member) {
+            return CreatorInfo.builder()
+                    .memberId(member.getId())
+                    .name(member.getName())
+                    .email(member.getEmail())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/TeamSummaryResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/TeamSummaryResponse.java
@@ -1,0 +1,33 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamMember;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+
+@Data
+@Builder
+public class TeamSummaryResponse {
+
+    private Long teamId;
+    private String name;
+    private String description;
+    private String teamProfileImgUrl;
+    private String myRole;
+    private int memberCount;
+    private Instant createdAt;
+
+    public static TeamSummaryResponse of(Team team, TeamMember myMembership, int memberCount) {
+        return TeamSummaryResponse.builder()
+                .teamId(team.getId())
+                .name(team.getName())
+                .description(team.getDescription())
+                .teamProfileImgUrl(team.getTeamProfileImgUrl())
+                .myRole(myMembership.getRole().name())
+                .memberCount(memberCount)
+                .createdAt(team.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/Team.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/Team.java
@@ -1,0 +1,4 @@
+package com.writingboard.server.domain.team.entity;
+
+public class Team {
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/Team.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/Team.java
@@ -1,4 +1,53 @@
 package com.writingboard.server.domain.team.entity;
 
-public class Team {
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "team")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Team extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_id")
+    private Long id;
+
+    @Column(name = "name", length = 100, nullable = false)
+    private String name;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "team_profile_img_url", length = 255)
+    private String teamProfileImgUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by_member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_team_creator"))
+    private Member createdBy;
+
+    public static Team create(Member creator, String name, String description) {
+        Team team = new Team();
+        team.createdBy = creator;
+        team.name = name;
+        team.description = description;
+        return team;
+    }
+
+    public void updateInfo(String name, String description, String teamProfileImgUrl) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (teamProfileImgUrl != null) {
+            this.teamProfileImgUrl = teamProfileImgUrl;
+        }
+    }
 }

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamAsset.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamAsset.java
@@ -1,4 +1,124 @@
 package com.writingboard.server.domain.team.entity;
 
-public class TeamAsset {
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.team.entity.enums.AssetSourceType;
+import com.writingboard.server.domain.team.entity.enums.AssetStatus;
+import com.writingboard.server.domain.team.entity.enums.AssetType;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "team_asset")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamAsset extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_asset_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false, foreignKey = @ForeignKey(name = "fk_team_asset_team"))
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "uploader_id", nullable = false, foreignKey = @ForeignKey(name = "fk_team_asset_uploader"))
+    private Member uploader;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_asset_id", foreignKey = @ForeignKey(name = "fk_team_asset_parent"))
+    private TeamAsset parentAsset;
+
+    @Column(name = "origin_personal_asset_id")
+    private Long originPersonalAssetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", length = 20, nullable = false)
+    private AssetSourceType sourceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 20, nullable = false)
+    private AssetType type;
+
+    @Column(name = "name", length = 255, nullable = false)
+    private String name;
+
+    @Column(name = "storage_key", length = 500)
+    private String storageKey;
+
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @Column(name = "is_latest", nullable = false)
+    private Boolean isLatest;
+
+    @Column(name = "total_pages")
+    private Integer totalPages;
+
+    @Column(name = "thumbnail_image_url", length = 500)
+    private String thumbnailImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private AssetStatus status;
+
+    public static TeamAsset create(Team team, Member uploader, AssetType type, String name, AssetSourceType sourceType) {
+        TeamAsset asset = new TeamAsset();
+        asset.team = team;
+        asset.uploader = uploader;
+        asset.type = type;
+        asset.name = name;
+        asset.sourceType = sourceType;
+        asset.version = 1;
+        asset.isLatest = true;
+        asset.status = AssetStatus.ACTIVE;
+        return asset;
+    }
+
+    public static TeamAsset createImported(Team team, Member uploader, AssetType type, String name, Long originPersonalAssetId) {
+        TeamAsset asset = create(team, uploader, type, name, AssetSourceType.IMPORTED);
+        asset.originPersonalAssetId = originPersonalAssetId;
+        return asset;
+    }
+
+    public TeamAsset createNewVersion(Member uploader) {
+        TeamAsset newVersion = new TeamAsset();
+        newVersion.team = this.team;
+        newVersion.uploader = uploader;
+        newVersion.parentAsset = this.parentAsset != null ? this.parentAsset : this;
+        newVersion.originPersonalAssetId = this.originPersonalAssetId;
+        newVersion.sourceType = this.sourceType;
+        newVersion.type = this.type;
+        newVersion.name = this.name;
+        newVersion.version = this.version + 1;
+        newVersion.isLatest = true;
+        newVersion.status = AssetStatus.ACTIVE;
+        return newVersion;
+    }
+
+    public void markAsNotLatest() {
+        this.isLatest = false;
+    }
+
+    public void updateName(String name) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+    }
+
+    public void delete() {
+        this.status = AssetStatus.DELETED;
+    }
+
+    public boolean isDeleted() {
+        return this.status == AssetStatus.DELETED;
+    }
+
+    public boolean isUploader(Long memberId) {
+        return this.uploader.getId().equals(memberId);
+    }
 }

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamAsset.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamAsset.java
@@ -1,0 +1,4 @@
+package com.writingboard.server.domain.team.entity;
+
+public class TeamAsset {
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamInvitation.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamInvitation.java
@@ -65,7 +65,7 @@ public class TeamInvitation extends BaseEntity {
         invitation.team = team;
         invitation.inviter = inviter;
         invitation.invitee = invitee;
-        invitation.type = TeamInvitationType.USER_SEARCH;
+        invitation.type = TeamInvitationType.DIRECT;
         invitation.inviteToken = null;
         invitation.expiresAt = null;
         invitation.status = TeamInvitationStatus.PENDING;
@@ -105,6 +105,6 @@ public class TeamInvitation extends BaseEntity {
     }
 
     public boolean isDirectInvitation() {
-        return this.type == TeamInvitationType.USER_SEARCH;
+        return this.type == TeamInvitationType.DIRECT;
     }
 }

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamInvitation.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamInvitation.java
@@ -1,0 +1,4 @@
+package com.writingboard.server.domain.team.entity;
+
+public class TeamInvitation {
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamInvitation.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamInvitation.java
@@ -1,4 +1,110 @@
 package com.writingboard.server.domain.team.entity;
 
-public class TeamInvitation {
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.team.entity.enums.TeamInvitationStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamInvitationType;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "team_invitation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamInvitation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "invite_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false, foreignKey = @ForeignKey(name = "fk_team_invitation_team"))
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "inviter_member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_team_invitation_inviter"))
+    private Member inviter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitee_member_id", foreignKey = @ForeignKey(name = "fk_team_invitation_invitee"))
+    private Member invitee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 20, nullable = false)
+    private TeamInvitationType type;
+
+    @Column(name = "invite_token", length = 128, unique = true)
+    private String inviteToken;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private TeamInvitationStatus status;
+
+    public static TeamInvitation createLinkInvitation(Team team, Member inviter, String token, Instant expiresAt) {
+        TeamInvitation invitation = new TeamInvitation();
+        invitation.team = team;
+        invitation.inviter = inviter;
+        invitation.invitee = null;
+        invitation.type = TeamInvitationType.LINK;
+        invitation.inviteToken = token;
+        invitation.expiresAt = expiresAt;
+        invitation.status = TeamInvitationStatus.PENDING;
+        return invitation;
+    }
+
+    public static TeamInvitation createDirectInvitation(Team team, Member inviter, Member invitee) {
+        TeamInvitation invitation = new TeamInvitation();
+        invitation.team = team;
+        invitation.inviter = inviter;
+        invitation.invitee = invitee;
+        invitation.type = TeamInvitationType.USER_SEARCH;
+        invitation.inviteToken = null;
+        invitation.expiresAt = null;
+        invitation.status = TeamInvitationStatus.PENDING;
+        return invitation;
+    }
+
+    public void accept() {
+        this.status = TeamInvitationStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = TeamInvitationStatus.REJECTED;
+    }
+
+    public void expire() {
+        this.status = TeamInvitationStatus.EXPIRED;
+    }
+
+    public boolean isUsable() {
+        if (status != TeamInvitationStatus.PENDING) {
+            return false;
+        }
+        return expiresAt == null || !expiresAt.isBefore(Instant.now());
+    }
+
+    public void checkAndExpire() {
+        if (status != TeamInvitationStatus.PENDING) {
+            return;
+        }
+        if (expiresAt != null && expiresAt.isBefore(Instant.now())) {
+            this.status = TeamInvitationStatus.EXPIRED;
+        }
+    }
+
+    public boolean isLinkInvitation() {
+        return this.type == TeamInvitationType.LINK;
+    }
+
+    public boolean isDirectInvitation() {
+        return this.type == TeamInvitationType.USER_SEARCH;
+    }
 }

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamMember.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamMember.java
@@ -1,4 +1,107 @@
 package com.writingboard.server.domain.team.entity;
 
-public class TeamMember {
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "team_member",
+        uniqueConstraints = @UniqueConstraint(name = "uk_team_member", columnNames = {"team_id", "member_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_member_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false, foreignKey = @ForeignKey(name = "fk_team_member_team"))
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_team_member_member"))
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", length = 20, nullable = false)
+    private TeamRole role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private TeamMemberStatus status;
+
+    @Column(name = "joined_at")
+    private Instant joinedAt;
+
+    public static TeamMember createOwner(Team team, Member member) {
+        TeamMember tm = new TeamMember();
+        tm.team = team;
+        tm.member = member;
+        tm.role = TeamRole.OWNER;
+        tm.status = TeamMemberStatus.ACTIVE;
+        tm.joinedAt = Instant.now();
+        return tm;
+    }
+
+    public static TeamMember createMember(Team team, Member member) {
+        TeamMember tm = new TeamMember();
+        tm.team = team;
+        tm.member = member;
+        tm.role = TeamRole.MEMBER;
+        tm.status = TeamMemberStatus.ACTIVE;
+        tm.joinedAt = Instant.now();
+        return tm;
+    }
+
+    public static TeamMember createPending(Team team, Member member) {
+        TeamMember tm = new TeamMember();
+        tm.team = team;
+        tm.member = member;
+        tm.role = TeamRole.MEMBER;
+        tm.status = TeamMemberStatus.PENDING;
+        tm.joinedAt = null;
+        return tm;
+    }
+
+    public void activate() {
+        this.status = TeamMemberStatus.ACTIVE;
+        this.joinedAt = Instant.now();
+    }
+
+    public void leave() {
+        this.status = TeamMemberStatus.LEFT;
+    }
+
+    public void promoteToAdmin() {
+        this.role = TeamRole.ADMIN;
+    }
+
+    public void demoteToMember() {
+        this.role = TeamRole.MEMBER;
+    }
+
+    public boolean isOwner() {
+        return this.role == TeamRole.OWNER;
+    }
+
+    public boolean isAdmin() {
+        return this.role == TeamRole.ADMIN;
+    }
+
+    public boolean isAdminOrOwner() {
+        return this.role == TeamRole.OWNER || this.role == TeamRole.ADMIN;
+    }
+
+    public boolean isActive() {
+        return this.status == TeamMemberStatus.ACTIVE;
+    }
 }

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamMember.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamMember.java
@@ -1,0 +1,4 @@
+package com.writingboard.server.domain.team.entity;
+
+public class TeamMember {
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/AssetSourceType.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/AssetSourceType.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum AssetSourceType {
+    UPLOADED,  // 직접 업로드
+    IMPORTED   // 개인 자산에서 가져옴
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/AssetStatus.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/AssetStatus.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum AssetStatus {
+    ACTIVE,   // 활성 상태
+    DELETED   // 삭제됨 (Soft Delete)
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/AssetType.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/AssetType.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum AssetType {
+    PDF,
+    IMAGE
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamInvitationStatus.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamInvitationStatus.java
@@ -1,0 +1,8 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum TeamInvitationStatus {
+    PENDING,   // 대기 중
+    ACCEPTED,  // 수락됨
+    EXPIRED,   // 만료됨
+    REJECTED   // 거절됨
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamInvitationType.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamInvitationType.java
@@ -1,6 +1,6 @@
 package com.writingboard.server.domain.team.entity.enums;
 
 public enum TeamInvitationType {
-    LINK,        // 초대 링크 (누구나 사용 가능)
-    USER_SEARCH  // 사용자 검색으로 직접 초대
+    LINK,
+    DIRECT
 }

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamInvitationType.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamInvitationType.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum TeamInvitationType {
+    LINK,        // 초대 링크 (누구나 사용 가능)
+    USER_SEARCH  // 사용자 검색으로 직접 초대
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamMemberStatus.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamMemberStatus.java
@@ -1,0 +1,7 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum TeamMemberStatus {
+    ACTIVE,   // 활성 멤버
+    PENDING,  // 초대 대기 중
+    LEFT      // 탈퇴함
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamRole.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/TeamRole.java
@@ -1,0 +1,7 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum TeamRole {
+    OWNER,   // 팀 생성자 (최고 권한)
+    ADMIN,   // 관리자 (팀원 관리 가능)
+    MEMBER   // 일반 멤버
+}

--- a/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
@@ -1,0 +1,38 @@
+package com.writingboard.server.domain.team.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TeamErrorCode {
+
+    // Team
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_001", "팀을 찾을 수 없습니다"),
+    TEAM_NAME_DUPLICATED(HttpStatus.BAD_REQUEST, "TEAM_002", "이미 존재하는 팀 이름입니다"),
+
+    // Team Member - 권한 관련
+    NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "TEAM_101", "팀 멤버가 아닙니다"),
+    NOT_TEAM_ADMIN(HttpStatus.FORBIDDEN, "TEAM_102", "관리자 권한이 필요합니다"),
+    NOT_TEAM_OWNER(HttpStatus.FORBIDDEN, "TEAM_103", "팀 소유자만 가능합니다"),
+    CANNOT_CHANGE_OWNER_ROLE(HttpStatus.BAD_REQUEST, "TEAM_104", "소유자 권한은 변경할 수 없습니다"),
+    CANNOT_DEMOTE_SELF(HttpStatus.BAD_REQUEST, "TEAM_105", "자신의 권한은 강등할 수 없습니다"),
+    OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "TEAM_106", "팀 소유자는 팀을 탈퇴할 수 없습니다"),
+    CANNOT_KICK_OWNER(HttpStatus.BAD_REQUEST, "TEAM_107", "팀 소유자는 강퇴할 수 없습니다"),
+    CANNOT_KICK_SELF(HttpStatus.BAD_REQUEST, "TEAM_108", "자기 자신은 강퇴할 수 없습니다"),
+
+    // Team Invitation
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_201", "초대를 찾을 수 없습니다"),
+    INVITATION_EXPIRED(HttpStatus.BAD_REQUEST, "TEAM_202", "만료된 초대입니다"),
+    ALREADY_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "TEAM_203", "이미 팀 멤버입니다"),
+    ALREADY_INVITED(HttpStatus.BAD_REQUEST, "TEAM_204", "이미 초대된 사용자입니다"),
+    INVALID_INVITATION(HttpStatus.BAD_REQUEST, "TEAM_205", "유효하지 않은 초대입니다"),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_301", "사용자를 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
@@ -30,7 +30,13 @@ public enum TeamErrorCode {
     INVALID_INVITATION(HttpStatus.BAD_REQUEST, "TEAM_205", "유효하지 않은 초대입니다"),
 
     // Member
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_301", "사용자를 찾을 수 없습니다");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_301", "사용자를 찾을 수 없습니다"),
+
+    // Team Asset
+    ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_401", "자산을 찾을 수 없습니다"),
+    ASSET_MODIFY_FORBIDDEN(HttpStatus.FORBIDDEN, "TEAM_402", "자산을 수정/삭제할 권한이 없습니다"),
+    ASSET_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "TEAM_403", "이미 삭제된 자산입니다"),
+    INVALID_ASSET_TYPE(HttpStatus.BAD_REQUEST, "TEAM_404", "지원하지 않는 파일 타입입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/writingboard/server/domain/team/exception/TeamException.java
+++ b/src/main/java/com/writingboard/server/domain/team/exception/TeamException.java
@@ -1,0 +1,19 @@
+package com.writingboard.server.domain.team.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TeamException extends RuntimeException {
+
+    private final TeamErrorCode errorCode;
+
+    public TeamException(TeamErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public TeamException(TeamErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamAssetRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamAssetRepository.java
@@ -1,0 +1,27 @@
+package com.writingboard.server.domain.team.repository;
+
+import com.writingboard.server.domain.team.entity.TeamAsset;
+import com.writingboard.server.domain.team.entity.enums.AssetStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamAssetRepository extends JpaRepository<TeamAsset, Long> {
+
+    Optional<TeamAsset> findByIdAndStatus(Long id, AssetStatus status);
+
+    Optional<TeamAsset> findByIdAndTeamIdAndStatus(Long id, Long teamId, AssetStatus status);
+
+    Page<TeamAsset> findByTeamIdAndStatusAndIsLatestTrue(Long teamId, AssetStatus status, Pageable pageable);
+
+    @Query("SELECT a FROM TeamAsset a WHERE (a.parentAsset.id = :rootAssetId OR a.id = :rootAssetId) AND a.status = :status ORDER BY a.version DESC")
+    List<TeamAsset> findVersionHistory(@Param("rootAssetId") Long rootAssetId, @Param("status") AssetStatus status);
+
+    @Query("SELECT a FROM TeamAsset a WHERE a.id = :assetId OR a.parentAsset.id = :assetId ORDER BY a.version DESC")
+    List<TeamAsset> findAllVersions(@Param("assetId") Long assetId);
+}

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamInvitationRepository.java
@@ -1,0 +1,23 @@
+package com.writingboard.server.domain.team.repository;
+
+import com.writingboard.server.domain.team.entity.TeamInvitation;
+import com.writingboard.server.domain.team.entity.enums.TeamInvitationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, Long> {
+
+    Optional<TeamInvitation> findByInviteToken(String inviteToken);
+
+    Optional<TeamInvitation> findByTeamIdAndInviteeIdAndStatus(Long teamId, Long inviteeId, TeamInvitationStatus status);
+
+    List<TeamInvitation> findByTeamIdAndStatus(Long teamId, TeamInvitationStatus status);
+
+    List<TeamInvitation> findByInviteeIdAndStatus(Long inviteeId, TeamInvitationStatus status);
+
+    boolean existsByTeamIdAndInviteeIdAndStatus(Long teamId, Long inviteeId, TeamInvitationStatus status);
+
+    boolean existsByInviteToken(String inviteToken);
+}

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamMemberRepository.java
@@ -1,0 +1,26 @@
+package com.writingboard.server.domain.team.repository;
+
+import com.writingboard.server.domain.team.entity.TeamMember;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    Optional<TeamMember> findByTeamIdAndMemberId(Long teamId, Long memberId);
+
+    Optional<TeamMember> findByTeamIdAndMemberIdAndStatus(Long teamId, Long memberId, TeamMemberStatus status);
+
+    List<TeamMember> findByTeamIdAndStatus(Long teamId, TeamMemberStatus status);
+
+    List<TeamMember> findByMemberIdAndStatus(Long memberId, TeamMemberStatus status);
+
+    boolean existsByTeamIdAndMemberIdAndStatus(Long teamId, Long memberId, TeamMemberStatus status);
+
+    boolean existsByTeamIdAndMemberIdAndRoleIn(Long teamId, Long memberId, List<TeamRole> roles);
+
+    boolean existsByTeamIdAndMemberIdAndStatusAndRoleIn(Long teamId, Long memberId, TeamMemberStatus status, List<TeamRole> roles);
+}

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamRepository.java
@@ -1,0 +1,13 @@
+package com.writingboard.server.domain.team.repository;
+
+import com.writingboard.server.domain.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+
+    Optional<Team> findByIdAndCreatedById(Long teamId, Long memberId);
+
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamAssetService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamAssetService.java
@@ -1,0 +1,160 @@
+package com.writingboard.server.domain.team.service;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.dto.request.AssetCreateRequest;
+import com.writingboard.server.domain.team.dto.request.AssetUpdateRequest;
+import com.writingboard.server.domain.team.dto.response.AssetListResponse;
+import com.writingboard.server.domain.team.dto.response.AssetResponse;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamAsset;
+import com.writingboard.server.domain.team.entity.enums.AssetSourceType;
+import com.writingboard.server.domain.team.entity.enums.AssetStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import com.writingboard.server.domain.team.exception.TeamErrorCode;
+import com.writingboard.server.domain.team.exception.TeamException;
+import com.writingboard.server.domain.team.repository.TeamAssetRepository;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamAssetService {
+
+    private final TeamAssetRepository teamAssetRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public AssetResponse createAsset(Long memberId, Long teamId, AssetCreateRequest request) {
+        Team team = getTeamById(teamId);
+        Member uploader = getMemberById(memberId);
+        validateTeamMember(teamId, memberId);
+
+        TeamAsset asset;
+        if (request.getSourceType() == AssetSourceType.IMPORTED && request.getOriginPersonalAssetId() != null) {
+            asset = TeamAsset.createImported(team, uploader, request.getType(), request.getName(), request.getOriginPersonalAssetId());
+        } else {
+            asset = TeamAsset.create(team, uploader, request.getType(), request.getName(), AssetSourceType.UPLOADED);
+        }
+
+        teamAssetRepository.save(asset);
+        return AssetResponse.of(asset);
+    }
+
+    public AssetListResponse getAssets(Long memberId, Long teamId, Pageable pageable) {
+        validateTeamMember(teamId, memberId);
+
+        Page<TeamAsset> assetPage = teamAssetRepository.findByTeamIdAndStatusAndIsLatestTrue(
+                teamId, AssetStatus.ACTIVE, pageable);
+
+        Page<AssetResponse> responsePage = assetPage.map(AssetResponse::of);
+        return AssetListResponse.of(responsePage);
+    }
+
+    public AssetResponse getAsset(Long memberId, Long teamId, Long assetId) {
+        validateTeamMember(teamId, memberId);
+
+        TeamAsset asset = getActiveAssetByTeam(assetId, teamId);
+        return AssetResponse.of(asset);
+    }
+
+    public List<AssetResponse> getVersionHistory(Long memberId, Long teamId, Long assetId) {
+        validateTeamMember(teamId, memberId);
+
+        TeamAsset asset = getActiveAssetByTeam(assetId, teamId);
+
+        Long rootAssetId = asset.getParentAsset() != null ? asset.getParentAsset().getId() : asset.getId();
+        List<TeamAsset> versions = teamAssetRepository.findVersionHistory(rootAssetId, AssetStatus.ACTIVE);
+
+        return versions.stream()
+                .map(AssetResponse::of)
+                .toList();
+    }
+
+    @Transactional
+    public AssetResponse updateAsset(Long memberId, Long teamId, Long assetId, AssetUpdateRequest request) {
+        validateTeamMember(teamId, memberId);
+
+        TeamAsset asset = getActiveAssetByTeam(assetId, teamId);
+        validateModifyPermission(teamId, memberId, asset);
+
+        asset.updateName(request.getName());
+        return AssetResponse.of(asset);
+    }
+
+    @Transactional
+    public void deleteAsset(Long memberId, Long teamId, Long assetId) {
+        validateTeamMember(teamId, memberId);
+
+        TeamAsset asset = getActiveAssetByTeam(assetId, teamId);
+        validateModifyPermission(teamId, memberId, asset);
+
+        if (asset.isDeleted()) {
+            throw new TeamException(TeamErrorCode.ASSET_ALREADY_DELETED);
+        }
+
+        asset.delete();
+    }
+
+    @Transactional
+    public AssetResponse createNewVersion(Long memberId, Long teamId, Long assetId) {
+        validateTeamMember(teamId, memberId);
+
+        TeamAsset existingAsset = getActiveAssetByTeam(assetId, teamId);
+        Member uploader = getMemberById(memberId);
+
+        existingAsset.markAsNotLatest();
+
+        TeamAsset newVersion = existingAsset.createNewVersion(uploader);
+        teamAssetRepository.save(newVersion);
+
+        return AssetResponse.of(newVersion);
+    }
+
+    // Helper methods
+    private Team getTeamById(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private TeamAsset getActiveAssetByTeam(Long assetId, Long teamId) {
+        return teamAssetRepository.findByIdAndTeamIdAndStatus(assetId, teamId, AssetStatus.ACTIVE)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.ASSET_NOT_FOUND));
+    }
+
+    private void validateTeamMember(Long teamId, Long memberId) {
+        boolean isMember = teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(teamId, memberId, TeamMemberStatus.ACTIVE);
+        if (!isMember) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_MEMBER);
+        }
+    }
+
+    private void validateModifyPermission(Long teamId, Long memberId, TeamAsset asset) {
+        if (asset.isUploader(memberId)) {
+            return;
+        }
+
+        boolean isAdminOrOwner = teamMemberRepository.existsByTeamIdAndMemberIdAndStatusAndRoleIn(
+                teamId, memberId, TeamMemberStatus.ACTIVE, List.of(TeamRole.OWNER, TeamRole.ADMIN));
+
+        if (!isAdminOrOwner) {
+            throw new TeamException(TeamErrorCode.ASSET_MODIFY_FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamInvitationService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamInvitationService.java
@@ -1,0 +1,218 @@
+package com.writingboard.server.domain.team.service;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.dto.request.DirectInviteRequest;
+import com.writingboard.server.domain.team.dto.request.TeamInviteLinkRequest;
+import com.writingboard.server.domain.team.dto.response.TeamInvitationResponse;
+import com.writingboard.server.domain.team.dto.response.TeamInviteLinkResponse;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamInvitation;
+import com.writingboard.server.domain.team.entity.TeamMember;
+import com.writingboard.server.domain.team.entity.enums.TeamInvitationStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import com.writingboard.server.domain.team.exception.TeamErrorCode;
+import com.writingboard.server.domain.team.exception.TeamException;
+import com.writingboard.server.domain.team.repository.TeamInvitationRepository;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamInvitationService {
+
+    private static final int DEFAULT_EXPIRE_MINUTES = 60;
+
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamInvitationRepository teamInvitationRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public TeamInviteLinkResponse createLinkInvitation(Long memberId, Long teamId, TeamInviteLinkRequest request) {
+        Team team = getTeamById(teamId);
+        Member inviter = getMemberById(memberId);
+        validateAdminOrOwner(teamId, memberId);
+
+        int expireMinutes = request != null && request.getExpiresInMinutes() != null
+                ? request.getExpiresInMinutes() : DEFAULT_EXPIRE_MINUTES;
+
+        String token = UUID.randomUUID().toString();
+        Instant expiresAt = Instant.now().plus(expireMinutes, ChronoUnit.MINUTES);
+
+        TeamInvitation invitation = TeamInvitation.createLinkInvitation(team, inviter, token, expiresAt);
+        teamInvitationRepository.save(invitation);
+
+        return TeamInviteLinkResponse.of(invitation);
+    }
+
+    @Transactional
+    public TeamInvitationResponse createDirectInvitation(Long memberId, Long teamId, DirectInviteRequest request) {
+        Team team = getTeamById(teamId);
+        Member inviter = getMemberById(memberId);
+        validateAdminOrOwner(teamId, memberId);
+
+        // 초대 대상 찾기
+        Member invitee = null;
+        if (request.getMemberId() != null) {
+            invitee = getMemberById(request.getMemberId());
+        } else if (request.getMemberName() != null && !request.getMemberName().isBlank()) {
+            invitee = memberRepository.findByName(request.getMemberName())
+                    .orElseThrow(() -> new TeamException(TeamErrorCode.MEMBER_NOT_FOUND));
+        } else {
+            throw new TeamException(TeamErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        // 이미 팀 멤버인지 확인
+        if (teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(teamId, invitee.getId(), TeamMemberStatus.ACTIVE)) {
+            throw new TeamException(TeamErrorCode.ALREADY_TEAM_MEMBER);
+        }
+
+        // 이미 초대된 상태인지 확인
+        if (teamInvitationRepository.existsByTeamIdAndInviteeIdAndStatus(teamId, invitee.getId(), TeamInvitationStatus.PENDING)) {
+            throw new TeamException(TeamErrorCode.ALREADY_INVITED);
+        }
+
+        TeamInvitation invitation = TeamInvitation.createDirectInvitation(team, inviter, invitee);
+        teamInvitationRepository.save(invitation);
+
+        return TeamInvitationResponse.of(invitation);
+    }
+
+    @Transactional
+    public void acceptLinkInvitation(Long memberId, String inviteToken) {
+        TeamInvitation invitation = teamInvitationRepository.findByInviteToken(inviteToken)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.INVITATION_NOT_FOUND));
+
+        invitation.checkAndExpire();
+
+        if (!invitation.isUsable()) {
+            throw new TeamException(TeamErrorCode.INVITATION_EXPIRED);
+        }
+
+        Member member = getMemberById(memberId);
+        Long teamId = invitation.getTeam().getId();
+
+        // 이미 팀 멤버인지 확인
+        if (teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(teamId, memberId, TeamMemberStatus.ACTIVE)) {
+            throw new TeamException(TeamErrorCode.ALREADY_TEAM_MEMBER);
+        }
+
+        // 기존에 LEFT 상태인 멤버인지 확인
+        TeamMember existingMember = teamMemberRepository.findByTeamIdAndMemberId(teamId, memberId).orElse(null);
+        if (existingMember != null) {
+            existingMember.activate();
+        } else {
+            TeamMember newMember = TeamMember.createMember(invitation.getTeam(), member);
+            teamMemberRepository.save(newMember);
+        }
+
+        // 링크 초대는 여러 번 사용 가능하므로 상태 변경 안함
+    }
+
+    @Transactional
+    public void acceptDirectInvitation(Long memberId, Long invitationId) {
+        TeamInvitation invitation = teamInvitationRepository.findById(invitationId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.INVITATION_NOT_FOUND));
+
+        if (!invitation.isDirectInvitation()) {
+            throw new TeamException(TeamErrorCode.INVALID_INVITATION);
+        }
+
+        if (invitation.getInvitee() == null || !invitation.getInvitee().getId().equals(memberId)) {
+            throw new TeamException(TeamErrorCode.INVALID_INVITATION);
+        }
+
+        if (!invitation.isUsable()) {
+            throw new TeamException(TeamErrorCode.INVITATION_EXPIRED);
+        }
+
+        Long teamId = invitation.getTeam().getId();
+
+        // 이미 팀 멤버인지 확인
+        if (teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(teamId, memberId, TeamMemberStatus.ACTIVE)) {
+            throw new TeamException(TeamErrorCode.ALREADY_TEAM_MEMBER);
+        }
+
+        Member member = getMemberById(memberId);
+
+        // 기존에 LEFT 상태인 멤버인지 확인
+        TeamMember existingMember = teamMemberRepository.findByTeamIdAndMemberId(teamId, memberId).orElse(null);
+        if (existingMember != null) {
+            existingMember.activate();
+        } else {
+            TeamMember newMember = TeamMember.createMember(invitation.getTeam(), member);
+            teamMemberRepository.save(newMember);
+        }
+
+        invitation.accept();
+    }
+
+    @Transactional
+    public void rejectInvitation(Long memberId, Long invitationId) {
+        TeamInvitation invitation = teamInvitationRepository.findById(invitationId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.INVITATION_NOT_FOUND));
+
+        if (!invitation.isDirectInvitation()) {
+            throw new TeamException(TeamErrorCode.INVALID_INVITATION);
+        }
+
+        if (invitation.getInvitee() == null || !invitation.getInvitee().getId().equals(memberId)) {
+            throw new TeamException(TeamErrorCode.INVALID_INVITATION);
+        }
+
+        invitation.reject();
+    }
+
+    public List<TeamInvitationResponse> getMyPendingInvitations(Long memberId) {
+        List<TeamInvitation> invitations = teamInvitationRepository.findByInviteeIdAndStatus(memberId, TeamInvitationStatus.PENDING);
+        return invitations.stream()
+                .map(TeamInvitationResponse::of)
+                .toList();
+    }
+
+    public List<TeamInvitationResponse> getTeamInvitations(Long memberId, Long teamId) {
+        validateTeamExists(teamId);
+        validateAdminOrOwner(teamId, memberId);
+
+        List<TeamInvitation> invitations = teamInvitationRepository.findByTeamIdAndStatus(teamId, TeamInvitationStatus.PENDING);
+        return invitations.stream()
+                .map(TeamInvitationResponse::of)
+                .toList();
+    }
+
+    // Helper methods
+    private Team getTeamById(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateTeamExists(Long teamId) {
+        if (!teamRepository.existsById(teamId)) {
+            throw new TeamException(TeamErrorCode.TEAM_NOT_FOUND);
+        }
+    }
+
+    private void validateAdminOrOwner(Long teamId, Long memberId) {
+        boolean isAdminOrOwner = teamMemberRepository.existsByTeamIdAndMemberIdAndStatusAndRoleIn(
+                teamId, memberId, TeamMemberStatus.ACTIVE, List.of(TeamRole.OWNER, TeamRole.ADMIN));
+        if (!isAdminOrOwner) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_ADMIN);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamInvitationService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamInvitationService.java
@@ -60,6 +60,7 @@ public class TeamInvitationService {
     public TeamInvitationResponse createDirectInvitation(Long memberId, Long teamId, DirectInviteRequest request) {
         Team team = getTeamById(teamId);
         Member inviter = getMemberById(memberId);
+
         validateAdminOrOwner(teamId, memberId);
 
         // 초대 대상 찾기

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamMemberService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamMemberService.java
@@ -1,0 +1,126 @@
+package com.writingboard.server.domain.team.service;
+
+import com.writingboard.server.domain.team.dto.request.RoleChangeRequest;
+import com.writingboard.server.domain.team.dto.response.TeamMemberResponse;
+import com.writingboard.server.domain.team.entity.TeamMember;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import com.writingboard.server.domain.team.exception.TeamErrorCode;
+import com.writingboard.server.domain.team.exception.TeamException;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamMemberService {
+
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+
+    public List<TeamMemberResponse> getTeamMembers(Long memberId, Long teamId) {
+        validateTeamExists(teamId);
+        validateTeamMember(teamId, memberId);
+
+        List<TeamMember> members = teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
+        return members.stream()
+                .map(TeamMemberResponse::of)
+                .toList();
+    }
+
+    @Transactional
+    public void leaveTeam(Long memberId, Long teamId) {
+        validateTeamExists(teamId);
+
+        TeamMember teamMember = getTeamMember(teamId, memberId);
+
+        if (teamMember.isOwner()) {
+            throw new TeamException(TeamErrorCode.OWNER_CANNOT_LEAVE);
+        }
+
+        teamMember.leave();
+    }
+
+    @Transactional
+    public void kickMember(Long memberId, Long teamId, Long targetMemberId) {
+        validateTeamExists(teamId);
+        validateAdminOrOwner(teamId, memberId);
+
+        if (memberId.equals(targetMemberId)) {
+            throw new TeamException(TeamErrorCode.CANNOT_KICK_SELF);
+        }
+
+        TeamMember targetTeamMember = getTeamMember(teamId, targetMemberId);
+
+        if (targetTeamMember.isOwner()) {
+            throw new TeamException(TeamErrorCode.CANNOT_KICK_OWNER);
+        }
+
+        targetTeamMember.leave();
+    }
+
+    @Transactional
+    public TeamMemberResponse changeRole(Long memberId, Long teamId, Long targetMemberId, RoleChangeRequest request) {
+        validateTeamExists(teamId);
+        validateAdminOrOwner(teamId, memberId);
+
+        TeamMember requester = getTeamMember(teamId, memberId);
+        TeamMember targetMember = getTeamMember(teamId, targetMemberId);
+
+        // OWNER 권한 변경 불가
+        if (targetMember.isOwner()) {
+            throw new TeamException(TeamErrorCode.CANNOT_CHANGE_OWNER_ROLE);
+        }
+
+        // OWNER로 변경 시도 불가
+        if (request.getNewRole() == TeamRole.OWNER) {
+            throw new TeamException(TeamErrorCode.CANNOT_CHANGE_OWNER_ROLE);
+        }
+
+        // 자신의 권한 강등 불가 (ADMIN이 자신을 MEMBER로 변경 시도)
+        if (memberId.equals(targetMemberId) && request.getNewRole() == TeamRole.MEMBER && requester.isAdmin()) {
+            throw new TeamException(TeamErrorCode.CANNOT_DEMOTE_SELF);
+        }
+
+        // 권한 변경
+        if (request.getNewRole() == TeamRole.ADMIN) {
+            targetMember.promoteToAdmin();
+        } else if (request.getNewRole() == TeamRole.MEMBER) {
+            targetMember.demoteToMember();
+        }
+
+        return TeamMemberResponse.of(targetMember);
+    }
+
+    // Helper methods
+    private void validateTeamExists(Long teamId) {
+        if (!teamRepository.existsById(teamId)) {
+            throw new TeamException(TeamErrorCode.TEAM_NOT_FOUND);
+        }
+    }
+
+    private TeamMember getTeamMember(Long teamId, Long memberId) {
+        return teamMemberRepository.findByTeamIdAndMemberIdAndStatus(teamId, memberId, TeamMemberStatus.ACTIVE)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.NOT_TEAM_MEMBER));
+    }
+
+    private void validateTeamMember(Long teamId, Long memberId) {
+        boolean isMember = teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(teamId, memberId, TeamMemberStatus.ACTIVE);
+        if (!isMember) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_MEMBER);
+        }
+    }
+
+    private void validateAdminOrOwner(Long teamId, Long memberId) {
+        boolean isAdminOrOwner = teamMemberRepository.existsByTeamIdAndMemberIdAndStatusAndRoleIn(
+                teamId, memberId, TeamMemberStatus.ACTIVE, List.of(TeamRole.OWNER, TeamRole.ADMIN));
+        if (!isAdminOrOwner) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_ADMIN);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamMemberService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamMemberService.java
@@ -23,7 +23,7 @@ public class TeamMemberService {
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
 
-    public List<TeamMemberResponse> getTeamMembers(Long memberId, Long teamId) {
+    public List<TeamMemberResponse> getTeamMembers(Long teamId, Long memberId) {
         validateTeamExists(teamId);
         validateTeamMember(teamId, memberId);
 

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamService.java
@@ -1,0 +1,152 @@
+package com.writingboard.server.domain.team.service;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.dto.request.TeamCreateRequest;
+import com.writingboard.server.domain.team.dto.request.TeamUpdateRequest;
+import com.writingboard.server.domain.team.dto.response.TeamResponse;
+import com.writingboard.server.domain.team.dto.response.TeamSummaryResponse;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamMember;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import com.writingboard.server.domain.team.exception.TeamErrorCode;
+import com.writingboard.server.domain.team.exception.TeamException;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public TeamResponse createTeam(Long memberId, TeamCreateRequest request) {
+        Member creator = getMemberById(memberId);
+
+        Team team = Team.create(creator, request.getName(), request.getDescription());
+        teamRepository.save(team);
+
+        List<TeamMember> teamMembers = new ArrayList<>();
+
+        // 생성자를 OWNER로 추가
+        TeamMember ownerMember = TeamMember.createOwner(team, creator);
+        teamMemberRepository.save(ownerMember);
+        teamMembers.add(ownerMember);
+
+        // memberIds로 초대된 멤버들 추가
+        if (request.getMemberIds() != null && !request.getMemberIds().isEmpty()) {
+            for (Long invitedMemberId : request.getMemberIds()) {
+                if (!invitedMemberId.equals(memberId)) {
+                    Member invitedMember = getMemberById(invitedMemberId);
+                    TeamMember tm = TeamMember.createMember(team, invitedMember);
+                    teamMemberRepository.save(tm);
+                    teamMembers.add(tm);
+                }
+            }
+        }
+
+        // memberNames로 초대된 멤버들 추가
+        if (request.getMemberNames() != null && !request.getMemberNames().isEmpty()) {
+            for (String memberName : request.getMemberNames()) {
+                memberRepository.findByName(memberName).ifPresent(invitedMember -> {
+                    if (!invitedMember.getId().equals(memberId) &&
+                            teamMembers.stream().noneMatch(tm -> tm.getMember().getId().equals(invitedMember.getId()))) {
+                        TeamMember tm = TeamMember.createMember(team, invitedMember);
+                        teamMemberRepository.save(tm);
+                        teamMembers.add(tm);
+                    }
+                });
+            }
+        }
+
+        return TeamResponse.of(team, teamMembers);
+    }
+
+    public TeamResponse getTeam(Long memberId, Long teamId) {
+        Team team = getTeamById(teamId);
+        validateTeamMember(teamId, memberId);
+
+        List<TeamMember> members = teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
+        return TeamResponse.of(team, members);
+    }
+
+    public List<TeamSummaryResponse> getMyTeams(Long memberId) {
+        List<TeamMember> myMemberships = teamMemberRepository.findByMemberIdAndStatus(memberId, TeamMemberStatus.ACTIVE);
+
+        return myMemberships.stream()
+                .map(membership -> {
+                    Team team = membership.getTeam();
+                    int memberCount = teamMemberRepository.findByTeamIdAndStatus(team.getId(), TeamMemberStatus.ACTIVE).size();
+                    return TeamSummaryResponse.of(team, membership, memberCount);
+                })
+                .toList();
+    }
+
+    @Transactional
+    public TeamResponse updateTeam(Long memberId, Long teamId, TeamUpdateRequest request) {
+        Team team = getTeamById(teamId);
+        validateAdminOrOwner(teamId, memberId);
+
+        team.updateInfo(request.getName(), request.getDescription(), request.getTeamProfileImgUrl());
+
+        List<TeamMember> members = teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
+        return TeamResponse.of(team, members);
+    }
+
+    @Transactional
+    public void deleteTeam(Long memberId, Long teamId) {
+        Team team = getTeamById(teamId);
+        validateOwner(teamId, memberId);
+
+        // 모든 팀 멤버 상태를 LEFT로 변경
+        List<TeamMember> members = teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
+        members.forEach(TeamMember::leave);
+
+        teamRepository.delete(team);
+    }
+
+    // Helper methods
+    private Team getTeamById(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateTeamMember(Long teamId, Long memberId) {
+        boolean isMember = teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(teamId, memberId, TeamMemberStatus.ACTIVE);
+        if (!isMember) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_MEMBER);
+        }
+    }
+
+    private void validateAdminOrOwner(Long teamId, Long memberId) {
+        boolean isAdminOrOwner = teamMemberRepository.existsByTeamIdAndMemberIdAndStatusAndRoleIn(
+                teamId, memberId, TeamMemberStatus.ACTIVE, List.of(TeamRole.OWNER, TeamRole.ADMIN));
+        if (!isAdminOrOwner) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_ADMIN);
+        }
+    }
+
+    private void validateOwner(Long teamId, Long memberId) {
+        boolean isOwner = teamMemberRepository.existsByTeamIdAndMemberIdAndStatusAndRoleIn(
+                teamId, memberId, TeamMemberStatus.ACTIVE, List.of(TeamRole.OWNER));
+        if (!isOwner) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_OWNER);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.writingboard.server.domain.auth.exception.AuthException;
 import com.writingboard.server.domain.chat.exception.ChatException;
 import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.member.exception.MemberException;
+import com.writingboard.server.domain.team.exception.TeamException;
 import com.writingboard.server.domain.voice.exception.VoiceException;
 import com.writingboard.server.global.common.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +53,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MemberException.class)
     public ResponseEntity<ErrorResponse> handleMemberException(MemberException e) {
         log.warn("MemberException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(TeamException.class)
+    public ResponseEntity<ErrorResponse> handleTeamException(TeamException e) {
+        log.warn("TeamException: {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,8 +5,7 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD}
     mongodb:
-      uri: mongodb://yoon9531:testpasswordadmin1234@localhost:27017/writing_db?authSource=writing_db
-
+      uri: mongodb://yoon9531:testpasswordadmin1234@localhost:27017/writing_db?authSource=admin
   datasource:
     url: jdbc:mysql://localhost:3306/writing_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: ${DB_USER}


### PR DESCRIPTION
### 관련 이슈 번호
#13 

### 개요
팀 생성/정보 수정/ 삭제 등의 기능을 추가하였고, 팀 자산, 초대 관련 기능까지 추가하여 구현함.

### 구현 상세

1. 팀 CRUD (`TeamController`)
- 팀을 생성하고 생성한 사용자는 OWNER의 권한을 가지게 된다.
- 자신이 속한 팀 목록 및 특정 팀의 상세 정보를 조회할 수 있다.
- 팀 정보 수정은 ADMIN, OWNER 권한을 가진 사용자만 할 수 있다.
- 팀 삭제는 OWNER 권한을 가진 사용자만 할 수 있습니다.

2. 초대 조회 및 수락/거절 (`InvitationController`)
- 자신에게 온 대기 중인 초대를 조회할 수 있다.
- 초대를 수락 혹은 거절할 수 있으며 `TeamInvitation` 테이블의 필드 값이 변경된다.

3. 초대 기능 (`TeamInvitationController`)
- 초대 토큰을 발급하여 초대 링크를 발급한다.
- 직접 초대는 TeamInvitation 테이블에 데이터를 저장하여 조회하고 수락/거절할 수 있다.
- 특정 팀에 대한 모든 초대 기록을 조회할 수 있다.

4. 팀 멤버 관리 기능 (`TeamMemberController`)
- 팀에 속한 사용자들을 조회할 수 있다.
- 사용자가 자체적으로 탈퇴를 진행할 수도 있고 ADMIN 혹은 OWNER의 권한을 가진 사용자가 강퇴할 수 있다.
- ADMIN 혹은 OWNER의 권한을 가진 사용자가 팀에 속한 다른 사용자의 권한을 변경할 수 있따.