### PR TITLE
[REFACTOR] 회의실 도메인의 팀 종속성 추가 및 관련 API 변경

### DIFF
--- a/erd.mermaid
+++ b/erd.mermaid
@@ -82,6 +82,7 @@ erDiagram
     bigint room_id PK
     bigint team_id FK
     bigint host_id FK
+    varchar room_uuid
     varchar title
     varchar password_hash
     varchar status "OPEN|CLOSED"
@@ -105,7 +106,6 @@ erDiagram
     bigint room_id FK
     bigint member_id FK
     varchar session_id "웹소켓 세션 id"
-    varchar join_type
     varchar role "HOST|MODERATOR|VIEWER"
     varchar state "JOINED|LEFT"
     datetime joined_at

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasController.java
@@ -1,0 +1,64 @@
+package com.writingboard.server.domain.meeting.controller;
+
+import com.writingboard.server.domain.meeting.dto.request.CanvasUpdateRequest;
+import com.writingboard.server.domain.meeting.dto.response.CanvasPageResponse;
+import com.writingboard.server.domain.meeting.dto.response.CanvasSnapshotResponse;
+import com.writingboard.server.domain.meeting.entity.enums.SnapshotTriggerType;
+import com.writingboard.server.domain.meeting.service.CanvasService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/rooms/{roomUuid}/canvas")
+@RequiredArgsConstructor
+@Tag(name = "Canvas", description = "필기 데이터 관리 API")
+public class CanvasController {
+
+    private final CanvasService canvasService;
+
+    @GetMapping("/{roomAssetId}/pages/{pageIndex}")
+    @Operation(summary = "필기 데이터 조회", description = "특정 페이지의 필기 데이터를 조회합니다")
+    public ResponseEntity<CanvasPageResponse> getCanvasPage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
+            @PathVariable int pageIndex) {
+        return ResponseEntity.ok(canvasService.getCanvasPage(memberId, roomUuid, roomAssetId, pageIndex));
+    }
+
+    @PutMapping("/{roomAssetId}/pages/{pageIndex}")
+    @Operation(summary = "필기 데이터 저장", description = "특정 페이지의 필기 데이터를 저장합니다")
+    public ResponseEntity<CanvasPageResponse> updateCanvasPage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
+            @PathVariable int pageIndex,
+            @RequestBody CanvasUpdateRequest request) {
+        return ResponseEntity.ok(canvasService.updateCanvasPage(memberId, roomUuid, roomAssetId, pageIndex, request));
+    }
+
+    @PostMapping("/{roomAssetId}/pages/{pageIndex}/snapshot")
+    @Operation(summary = "스냅샷 생성", description = "현재 필기 데이터의 스냅샷을 생성합니다")
+    public ResponseEntity<CanvasSnapshotResponse> createSnapshot(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
+            @PathVariable int pageIndex,
+            @RequestParam(defaultValue = "MANUAL") SnapshotTriggerType triggerType) {
+        return ResponseEntity.ok(canvasService.createSnapshot(memberId, roomUuid, roomAssetId, pageIndex, triggerType));
+    }
+
+    @PostMapping("/{roomAssetId}/pages/{pageIndex}/restore")
+    @Operation(summary = "스냅샷 복원", description = "가장 최근 스냅샷으로 필기 데이터를 복원합니다")
+    public ResponseEntity<CanvasPageResponse> restoreFromSnapshot(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
+            @PathVariable int pageIndex) {
+        return ResponseEntity.ok(canvasService.restoreFromSnapshot(memberId, roomUuid, roomAssetId, pageIndex));
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasFollowController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasFollowController.java
@@ -2,7 +2,7 @@ package com.writingboard.server.domain.meeting.controller;
 
 import com.writingboard.server.domain.meeting.dto.request.ViewingStateRequest;
 import com.writingboard.server.domain.meeting.dto.response.ParticipantViewingResponse;
-import com.writingboard.server.domain.meeting.service.FollowService;
+import com.writingboard.server.domain.meeting.service.CanvasFollowService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -19,7 +19,7 @@ import java.util.List;
 @Tag(name = "Follow", description = "페이지 팔로우 API")
 public class CanvasFollowController {
 
-    private final FollowService followService;
+    private final CanvasFollowService canvasFollowService;
 
     @PostMapping("/viewing")
     @Operation(summary = "현재 보고 있는 페이지 업데이트", description = "현재 보고 있는 자료와 페이지를 업데이트하고 다른 참가자에게 브로드캐스트합니다")
@@ -27,7 +27,7 @@ public class CanvasFollowController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable String roomUuid,
             @RequestBody @Valid ViewingStateRequest request) {
-        followService.updateViewingState(memberId, roomUuid, request.getRoomAssetId(), request.getPageIndex());
+        canvasFollowService.updateViewingState(memberId, roomUuid, request.getRoomAssetId(), request.getPageIndex());
         return ResponseEntity.ok().build();
     }
 
@@ -37,7 +37,7 @@ public class CanvasFollowController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable String roomUuid,
             @PathVariable Long targetMemberId) {
-        followService.startFollow(memberId, roomUuid, targetMemberId);
+        canvasFollowService.startFollow(memberId, roomUuid, targetMemberId);
         return ResponseEntity.ok().build();
     }
 
@@ -46,7 +46,7 @@ public class CanvasFollowController {
     public ResponseEntity<Void> stopFollow(
             @AuthenticationPrincipal Long memberId,
             @PathVariable String roomUuid) {
-        followService.stopFollow(memberId, roomUuid);
+        canvasFollowService.stopFollow(memberId, roomUuid);
         return ResponseEntity.noContent().build();
     }
 
@@ -55,6 +55,6 @@ public class CanvasFollowController {
     public ResponseEntity<List<ParticipantViewingResponse>> getParticipantsViewing(
             @AuthenticationPrincipal Long memberId,
             @PathVariable String roomUuid) {
-        return ResponseEntity.ok(followService.getParticipantsViewing(memberId, roomUuid));
+        return ResponseEntity.ok(canvasFollowService.getParticipantsViewing(memberId, roomUuid));
     }
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasFollowController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasFollowController.java
@@ -17,7 +17,7 @@ import java.util.List;
 @RequestMapping("/api/rooms/{roomUuid}/follow")
 @RequiredArgsConstructor
 @Tag(name = "Follow", description = "페이지 팔로우 API")
-public class FollowController {
+public class CanvasFollowController {
 
     private final FollowService followService;
 

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/FollowController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/FollowController.java
@@ -1,0 +1,60 @@
+package com.writingboard.server.domain.meeting.controller;
+
+import com.writingboard.server.domain.meeting.dto.request.ViewingStateRequest;
+import com.writingboard.server.domain.meeting.dto.response.ParticipantViewingResponse;
+import com.writingboard.server.domain.meeting.service.FollowService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/rooms/{roomUuid}/follow")
+@RequiredArgsConstructor
+@Tag(name = "Follow", description = "페이지 팔로우 API")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/viewing")
+    @Operation(summary = "현재 보고 있는 페이지 업데이트", description = "현재 보고 있는 자료와 페이지를 업데이트하고 다른 참가자에게 브로드캐스트합니다")
+    public ResponseEntity<Void> updateViewingState(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @RequestBody @Valid ViewingStateRequest request) {
+        followService.updateViewingState(memberId, roomUuid, request.getRoomAssetId(), request.getPageIndex());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{targetMemberId}")
+    @Operation(summary = "팔로우 시작", description = "특정 참가자를 팔로우하여 같은 페이지를 봅니다")
+    public ResponseEntity<Void> startFollow(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @PathVariable Long targetMemberId) {
+        followService.startFollow(memberId, roomUuid, targetMemberId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    @Operation(summary = "팔로우 종료", description = "팔로우를 종료합니다")
+    public ResponseEntity<Void> stopFollow(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid) {
+        followService.stopFollow(memberId, roomUuid);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/participants/viewing")
+    @Operation(summary = "참가자별 현재 페이지 조회", description = "모든 참가자가 현재 보고 있는 자료와 페이지를 조회합니다")
+    public ResponseEntity<List<ParticipantViewingResponse>> getParticipantsViewing(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid) {
+        return ResponseEntity.ok(followService.getParticipantsViewing(memberId, roomUuid));
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/RoomAssetController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/RoomAssetController.java
@@ -1,0 +1,73 @@
+package com.writingboard.server.domain.meeting.controller;
+
+import com.writingboard.server.domain.meeting.dto.request.LoadPersonalAssetRequest;
+import com.writingboard.server.domain.meeting.dto.request.LoadTeamAssetRequest;
+import com.writingboard.server.domain.meeting.dto.request.PageChangeRequest;
+import com.writingboard.server.domain.meeting.dto.response.RoomAssetResponse;
+import com.writingboard.server.domain.meeting.service.RoomAssetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/rooms/{roomUuid}/assets")
+@RequiredArgsConstructor
+@Tag(name = "Room Asset", description = "회의실 자료 관리 API")
+public class RoomAssetController {
+
+    private final RoomAssetService roomAssetService;
+
+    @PostMapping("/team")
+    @Operation(summary = "팀 자료 불러오기", description = "팀 자료를 회의실에 불러옵니다")
+    public ResponseEntity<RoomAssetResponse> loadTeamAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @RequestBody @Valid LoadTeamAssetRequest request) {
+        RoomAssetResponse response = roomAssetService.loadTeamAsset(memberId, roomUuid, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/personal")
+    @Operation(summary = "개인 자료 불러오기", description = "개인 자료를 팀 자료로 복사 후 회의실에 불러옵니다")
+    public ResponseEntity<RoomAssetResponse> loadPersonalAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @RequestBody @Valid LoadPersonalAssetRequest request) {
+        RoomAssetResponse response = roomAssetService.loadPersonalAsset(memberId, roomUuid, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "회의실 자료 목록 조회", description = "회의실에 불러온 자료 목록을 조회합니다")
+    public ResponseEntity<List<RoomAssetResponse>> getRoomAssets(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid) {
+        return ResponseEntity.ok(roomAssetService.getRoomAssets(memberId, roomUuid));
+    }
+
+    @PostMapping("/{roomAssetId}/activate")
+    @Operation(summary = "자료 활성화", description = "특정 자료를 화면에 활성화합니다")
+    public ResponseEntity<RoomAssetResponse> activateAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId) {
+        return ResponseEntity.ok(roomAssetService.activateAsset(memberId, roomUuid, roomAssetId));
+    }
+
+    @PostMapping("/{roomAssetId}/page")
+    @Operation(summary = "페이지 변경", description = "활성화된 자료의 페이지를 변경합니다")
+    public ResponseEntity<RoomAssetResponse> changePage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
+            @RequestBody @Valid PageChangeRequest request) {
+        return ResponseEntity.ok(roomAssetService.changePage(memberId, roomUuid, roomAssetId, request));
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/RoomController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/RoomController.java
@@ -86,7 +86,9 @@ public class RoomController {
             @AuthenticationPrincipal Long memberId,
             @PathVariable String roomUuid,
             @RequestBody(required = false) RoomJoinRequest request) {
-        return ResponseEntity.ok(roomService.joinRoom(memberId, roomUuid, request));
+
+        RoomJoinResponse joined = roomService.joinRoom(memberId, roomUuid, request);
+        return ResponseEntity.ok(joined);
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/RoomController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/RoomController.java
@@ -53,7 +53,9 @@ public class RoomController {
     @GetMapping("/{roomUuid}")
     public ResponseEntity<RoomDetailResponse> getRoom(
             @PathVariable String roomUuid) {
-        return ResponseEntity.ok(roomService.getRoom(roomUuid));
+
+        RoomDetailResponse roomDetail = roomService.getRoom(roomUuid);
+        return ResponseEntity.ok(roomDetail);
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/RoomController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/RoomController.java
@@ -32,8 +32,8 @@ public class RoomController {
             @AuthenticationPrincipal Long memberId,
             @RequestBody @Valid RoomCreateRequest request) {
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(roomService.createRoom(memberId, request));
+        RoomCreateResponse createdRoom = roomService.createRoom(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdRoom);
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/FollowStateDto.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/FollowStateDto.java
@@ -1,0 +1,31 @@
+package com.writingboard.server.domain.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowStateDto {
+
+    private Long memberId;
+    private String memberName;
+    private Long roomAssetId;
+    private Integer pageIndex;
+    private Instant timestamp;
+
+    public static FollowStateDto of(Long memberId, String memberName, Long roomAssetId, Integer pageIndex) {
+        return FollowStateDto.builder()
+                .memberId(memberId)
+                .memberName(memberName)
+                .roomAssetId(roomAssetId)
+                .pageIndex(pageIndex)
+                .timestamp(Instant.now())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/CanvasUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/CanvasUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.writingboard.server.domain.meeting.dto.request;
+
+import com.writingboard.server.domain.meeting.entity.enums.SnapshotTriggerType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CanvasUpdateRequest {
+
+    private String rawData;
+
+    private boolean createSnapshot;
+
+    private SnapshotTriggerType snapshotTriggerType;
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/LoadPersonalAssetRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/LoadPersonalAssetRequest.java
@@ -1,0 +1,18 @@
+package com.writingboard.server.domain.meeting.dto.request;
+
+import com.writingboard.server.domain.meeting.entity.enums.SavePolicy;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoadPersonalAssetRequest {
+
+    @NotNull(message = "개인 자료 ID는 필수입니다")
+    private Long personalAssetId;
+
+    private SavePolicy savePolicy;
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/LoadTeamAssetRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/LoadTeamAssetRequest.java
@@ -1,0 +1,18 @@
+package com.writingboard.server.domain.meeting.dto.request;
+
+import com.writingboard.server.domain.meeting.entity.enums.SavePolicy;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoadTeamAssetRequest {
+
+    @NotNull(message = "팀 자료 ID는 필수입니다")
+    private Long teamAssetId;
+
+    private SavePolicy savePolicy;
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/PageChangeRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/PageChangeRequest.java
@@ -1,0 +1,17 @@
+package com.writingboard.server.domain.meeting.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageChangeRequest {
+
+    @NotNull(message = "페이지 번호는 필수입니다")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    private Integer pageNumber;
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/RoomCreateRequest.java
@@ -7,6 +7,9 @@ import lombok.Data;
 @Data
 public class RoomCreateRequest {
 
+    @NotBlank(message = "팀 ID는 필수입니다")
+    private Long teamId;
+
     @NotBlank(message = "회의실 제목은 필수입니다")
     @Size(max = 100, message = "제목은 100자 이내여야 합니다")
     private String title;

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/RoomCreateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/RoomCreateRequest.java
@@ -1,13 +1,14 @@
 package com.writingboard.server.domain.meeting.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class RoomCreateRequest {
 
-    @NotBlank(message = "팀 ID는 필수입니다")
+    @NotNull
     private Long teamId;
 
     @NotBlank(message = "회의실 제목은 필수입니다")

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/ViewingStateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/ViewingStateRequest.java
@@ -1,0 +1,20 @@
+package com.writingboard.server.domain.meeting.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ViewingStateRequest {
+
+    @NotNull(message = "자료 ID는 필수입니다")
+    private Long roomAssetId;
+
+    @NotNull(message = "페이지 번호는 필수입니다")
+    @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다")
+    private Integer pageIndex;
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasPageResponse.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasPageResponse.java
@@ -1,0 +1,46 @@
+package com.writingboard.server.domain.meeting.dto.response;
+
+import com.writingboard.server.domain.meeting.entity.CanvasPage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.Base64;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CanvasPageResponse {
+
+    private Long id;
+    private Long roomAssetId;
+    private Integer pageIndex;
+    private String rawData;
+    private Instant lastUpdatedAt;
+
+    public static CanvasPageResponse from(CanvasPage canvasPage) {
+        String encodedData = null;
+        if (canvasPage.getRawData() != null) {
+            encodedData = Base64.getEncoder().encodeToString(canvasPage.getRawData());
+        }
+
+        return CanvasPageResponse.builder()
+                .id(canvasPage.getId())
+                .roomAssetId(canvasPage.getRoomAsset().getId())
+                .pageIndex(canvasPage.getPageIndex())
+                .rawData(encodedData)
+                .lastUpdatedAt(canvasPage.getLastUpdatedAt())
+                .build();
+    }
+
+    public static CanvasPageResponse empty(Long roomAssetId, int pageIndex) {
+        return CanvasPageResponse.builder()
+                .id(null)
+                .roomAssetId(roomAssetId)
+                .pageIndex(pageIndex)
+                .rawData(null)
+                .lastUpdatedAt(null)
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasSnapshotResponse.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasSnapshotResponse.java
@@ -1,0 +1,31 @@
+package com.writingboard.server.domain.meeting.dto.response;
+
+import com.writingboard.server.domain.meeting.entity.CanvasSnapshot;
+import com.writingboard.server.domain.meeting.entity.enums.SnapshotTriggerType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CanvasSnapshotResponse {
+
+    private Long id;
+    private Long roomAssetId;
+    private Integer pageIndex;
+    private SnapshotTriggerType triggerType;
+    private Instant createdAt;
+
+    public static CanvasSnapshotResponse from(CanvasSnapshot snapshot) {
+        return CanvasSnapshotResponse.builder()
+                .id(snapshot.getId())
+                .roomAssetId(snapshot.getRoomAsset().getId())
+                .pageIndex(snapshot.getPageIndex())
+                .triggerType(snapshot.getTriggerType())
+                .createdAt(snapshot.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/response/ParticipantViewingResponse.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/response/ParticipantViewingResponse.java
@@ -1,0 +1,19 @@
+package com.writingboard.server.domain.meeting.dto.response;
+
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ParticipantViewingResponse {
+
+    private Long memberId;
+    private String memberName;
+    private ParticipantRole role;
+    private Long roomAssetId;
+    private String assetName;
+    private Integer pageIndex;
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/response/RoomAssetResponse.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/response/RoomAssetResponse.java
@@ -1,0 +1,48 @@
+package com.writingboard.server.domain.meeting.dto.response;
+
+import com.writingboard.server.domain.meeting.entity.RoomAsset;
+import com.writingboard.server.domain.meeting.entity.enums.SavePolicy;
+import com.writingboard.server.domain.team.entity.enums.AssetType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RoomAssetResponse {
+
+    private Long id;
+    private Long teamAssetId;
+    private String assetName;
+    private AssetType assetType;
+    private Integer totalPages;
+    private Integer currentPageNumber;
+    private Boolean isActive;
+    private SavePolicy savePolicy;
+    private Long addedById;
+    private String addedByName;
+    private Instant createdAt;
+
+    public static RoomAssetResponse from(RoomAsset roomAsset) {
+        RoomAssetResponseBuilder builder = RoomAssetResponse.builder()
+                .id(roomAsset.getId())
+                .currentPageNumber(roomAsset.getCurrentPageNumber())
+                .isActive(roomAsset.getIsActive())
+                .savePolicy(roomAsset.getSavePolicy())
+                .addedById(roomAsset.getAddedBy().getId())
+                .addedByName(roomAsset.getAddedBy().getName())
+                .createdAt(roomAsset.getCreatedAt());
+
+        if (roomAsset.getTeamAsset() != null) {
+            builder.teamAssetId(roomAsset.getTeamAsset().getId())
+                    .assetName(roomAsset.getTeamAsset().getName())
+                    .assetType(roomAsset.getTeamAsset().getType())
+                    .totalPages(roomAsset.getTeamAsset().getTotalPages());
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasPage.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasPage.java
@@ -1,0 +1,50 @@
+package com.writingboard.server.domain.meeting.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "canvas_page", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_canvas_page_asset_index", columnNames = {"room_asset_id", "page_index"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CanvasPage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "canvas_page_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_asset_id", nullable = false, foreignKey = @ForeignKey(name = "fk_canvas_page_room_asset"))
+    private RoomAsset roomAsset;
+
+    @Column(name = "page_index", nullable = false)
+    private Integer pageIndex;
+
+    @Lob
+    @Column(name = "raw_data", columnDefinition = "LONGBLOB")
+    private byte[] rawData;
+
+    @Column(name = "last_updated_at", nullable = false)
+    private Instant lastUpdatedAt;
+
+    public static CanvasPage create(RoomAsset roomAsset, int pageIndex) {
+        CanvasPage page = new CanvasPage();
+        page.roomAsset = roomAsset;
+        page.pageIndex = pageIndex;
+        page.rawData = null;
+        page.lastUpdatedAt = Instant.now();
+        return page;
+    }
+
+    public void updateData(byte[] data) {
+        this.rawData = data;
+        this.lastUpdatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasSnapshot.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasSnapshot.java
@@ -1,0 +1,51 @@
+package com.writingboard.server.domain.meeting.entity;
+
+import com.writingboard.server.domain.meeting.entity.enums.SnapshotTriggerType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "canvas_snapshot", indexes = {
+        @Index(name = "idx_canvas_snapshot_asset_page", columnList = "room_asset_id, page_index")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CanvasSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "canvas_snapshot_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_asset_id", nullable = false, foreignKey = @ForeignKey(name = "fk_canvas_snapshot_room_asset"))
+    private RoomAsset roomAsset;
+
+    @Column(name = "page_index", nullable = false)
+    private Integer pageIndex;
+
+    @Lob
+    @Column(name = "stroke_data", columnDefinition = "LONGBLOB")
+    private byte[] strokeData;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trigger_type", length = 20, nullable = false)
+    private SnapshotTriggerType triggerType;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    public static CanvasSnapshot create(RoomAsset roomAsset, int pageIndex, byte[] strokeData, SnapshotTriggerType triggerType) {
+        CanvasSnapshot snapshot = new CanvasSnapshot();
+        snapshot.roomAsset = roomAsset;
+        snapshot.pageIndex = pageIndex;
+        snapshot.strokeData = strokeData;
+        snapshot.triggerType = triggerType;
+        snapshot.createdAt = Instant.now();
+        return snapshot;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
@@ -3,6 +3,7 @@ package com.writingboard.server.domain.meeting.entity;
 import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
 import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
 import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.team.entity.Team;
 import com.writingboard.server.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -25,6 +26,14 @@ public class Room extends BaseEntity {
     @Column(name = "room_id")
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "host_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_host"))
+    private Member host;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_team"))
+    private Team team;
+
     @Column(name = "room_uuid", length = 36, nullable = false)
     private String roomUuid;
 
@@ -33,10 +42,6 @@ public class Room extends BaseEntity {
 
     @Column(name = "password_hash", length = 255)
     private String passwordHash;
-
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "host_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_host"))
-    private Member host;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
@@ -40,7 +40,7 @@ public class Room extends BaseEntity {
     @Column(name = "title", length = 100, nullable = false)
     private String title;
 
-    @Column(name = "password_hash", length = 255)
+    @Column(name = "password_hash")
     private String passwordHash;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
@@ -59,6 +59,9 @@ public class Room extends BaseEntity {
     @OneToMany(mappedBy = "room", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RoomInvite> invites = new ArrayList<>();
 
+    @OneToMany(mappedBy = "room", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoomAsset> assets = new ArrayList<>();
+
     public static Room create(String roomUuid, String title, Member host, Team team, String passwordHash) {
         Room r = new Room();
         r.roomUuid = roomUuid;

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/Room.java
@@ -59,11 +59,12 @@ public class Room extends BaseEntity {
     @OneToMany(mappedBy = "room", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RoomInvite> invites = new ArrayList<>();
 
-    public static Room create(String roomUuid, String title, Member host, String passwordHash) {
+    public static Room create(String roomUuid, String title, Member host, Team team, String passwordHash) {
         Room r = new Room();
         r.roomUuid = roomUuid;
         r.title = title;
         r.host = host;
+        r.team = team;
         r.passwordHash = passwordHash;
         r.status = RoomStatus.OPEN;
         r.lastActivityAt = Instant.now();

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomAsset.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomAsset.java
@@ -1,0 +1,4 @@
+package com.writingboard.server.domain.meeting.entity;
+
+public class RoomAsset {
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomAsset.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomAsset.java
@@ -5,8 +5,17 @@ import com.writingboard.server.domain.member.entity.Member;
 import com.writingboard.server.domain.team.entity.TeamAsset;
 import com.writingboard.server.global.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
+@Table(name = "room_asset")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RoomAsset extends BaseEntity {
 
     @Id
@@ -18,21 +27,53 @@ public class RoomAsset extends BaseEntity {
     @JoinColumn(name = "room_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_asset_room"))
     private Room room;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_asset_id", foreignKey = @ForeignKey(name = "fk_room_asset_team_asset"))
     private TeamAsset teamAsset;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_asset_member"))
-    private Member member; // 회의실에 업로드한 멤버
+    @JoinColumn(name = "added_by_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_asset_added_by"))
+    private Member addedBy;
 
-    @Column(name = "current_page_number")
-    private Integer currentPageNumber;
+    @Column(name = "current_page_number", nullable = false)
+    private Integer currentPageNumber = 0;
 
     @Column(name = "is_active", nullable = false)
-    private Boolean isActive;
+    private Boolean isActive = false;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "save_policy", nullable = false)
     private SavePolicy savePolicy;
 
+    @OneToMany(mappedBy = "roomAsset", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CanvasPage> canvasPages = new ArrayList<>();
+
+    public static RoomAsset createFromTeamAsset(Room room, TeamAsset teamAsset, Member addedBy, SavePolicy savePolicy) {
+        RoomAsset asset = new RoomAsset();
+        asset.room = room;
+        asset.teamAsset = teamAsset;
+        asset.addedBy = addedBy;
+        asset.savePolicy = savePolicy;
+        asset.currentPageNumber = 0;
+        asset.isActive = false;
+        return asset;
+    }
+
+    public void activate() {
+        this.isActive = true;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void changePage(int pageNumber) {
+        if (pageNumber >= 0) {
+            this.currentPageNumber = pageNumber;
+        }
+    }
+
+    public boolean isAddedBy(Long memberId) {
+        return this.addedBy.getId().equals(memberId);
+    }
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomAsset.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomAsset.java
@@ -1,4 +1,38 @@
 package com.writingboard.server.domain.meeting.entity;
 
-public class RoomAsset {
+import com.writingboard.server.domain.meeting.entity.enums.SavePolicy;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.team.entity.TeamAsset;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+
+@Entity
+public class RoomAsset extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_asset_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "room_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_asset_room"))
+    private Room room;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_asset_id", foreignKey = @ForeignKey(name = "fk_room_asset_team_asset"))
+    private TeamAsset teamAsset;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_room_asset_member"))
+    private Member member; // 회의실에 업로드한 멤버
+
+    @Column(name = "current_page_number")
+    private Integer currentPageNumber;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @Column(name = "save_policy", nullable = false)
+    private SavePolicy savePolicy;
+
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
@@ -49,12 +49,6 @@ public class RoomInvite extends BaseEntity {
     @Column(name = "status", length = 20, nullable = false)
     private InviteStatus status = InviteStatus.ACTIVE;
 
-    @Column(name = "max_uses")
-    private Integer maxUses;
-
-    @Column(name = "used_count", nullable = false)
-    private Integer usedCount = 0;
-
     public static RoomInvite issue(Room room, Member issuedBy, Member usedBy, String token, InviteType type,
                                    Instant expiresAt) {
         RoomInvite i = new RoomInvite();
@@ -65,43 +59,16 @@ public class RoomInvite extends BaseEntity {
         i.type = type;
         i.expiresAt = expiresAt;
         i.status = InviteStatus.ACTIVE;
-        i.maxUses = null;
-        i.usedCount = 0;
-        return i;
-    }
-
-    public static RoomInvite issueOneTime(Room room, Member issuedBy, String token, InviteType type,
-                                          Instant expiresAt) {
-        RoomInvite i = issue(room, issuedBy, null, token, type, expiresAt);
-        i.maxUses = 1;
         return i;
     }
 
     public boolean isUsable() {
-        if (status == InviteStatus.EXPIRED || status == InviteStatus.USED) return false;
-        if (expiresAt != null && expiresAt.isBefore(Instant.now())) return false;
-        if (maxUses != null && usedCount >= maxUses) return false;
-        return true;
-    }
-
-    public boolean canUse() {
-        return isUsable();
-    }
-
-    public void use() {
-        this.usedCount++;
-        if (maxUses != null && usedCount >= maxUses) {
-            this.status = InviteStatus.USED;
-        }
-    }
-
-    public boolean hasUsageLimit() {
-        return this.maxUses != null;
+        if (status == InviteStatus.EXPIRED) return false;
+        return expiresAt == null || !expiresAt.isBefore(Instant.now());
     }
 
     /**
      * 초대가 만료됐는지 체크하고, 만료됐으면 상태를 EXPIRED로 변경
-     * DB Fallback 시 호출
      */
     public void checkAndExpire() {
         if (status == InviteStatus.EXPIRED) {

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
@@ -49,6 +49,12 @@ public class RoomInvite extends BaseEntity {
     @Column(name = "status", length = 20, nullable = false)
     private InviteStatus status = InviteStatus.ACTIVE;
 
+    @Column(name = "max_uses")
+    private Integer maxUses;
+
+    @Column(name = "used_count", nullable = false)
+    private Integer usedCount = 0;
+
     public static RoomInvite issue(Room room, Member issuedBy, Member usedBy, String token, InviteType type,
                                    Instant expiresAt) {
         RoomInvite i = new RoomInvite();
@@ -59,12 +65,38 @@ public class RoomInvite extends BaseEntity {
         i.type = type;
         i.expiresAt = expiresAt;
         i.status = InviteStatus.ACTIVE;
+        i.maxUses = null;
+        i.usedCount = 0;
+        return i;
+    }
+
+    public static RoomInvite issueOneTime(Room room, Member issuedBy, String token, InviteType type,
+                                          Instant expiresAt) {
+        RoomInvite i = issue(room, issuedBy, null, token, type, expiresAt);
+        i.maxUses = 1;
         return i;
     }
 
     public boolean isUsable() {
-        if (status == InviteStatus.EXPIRED) return false;
-        return expiresAt == null || !expiresAt.isBefore(Instant.now());
+        if (status == InviteStatus.EXPIRED || status == InviteStatus.USED) return false;
+        if (expiresAt != null && expiresAt.isBefore(Instant.now())) return false;
+        if (maxUses != null && usedCount >= maxUses) return false;
+        return true;
+    }
+
+    public boolean canUse() {
+        return isUsable();
+    }
+
+    public void use() {
+        this.usedCount++;
+        if (maxUses != null && usedCount >= maxUses) {
+            this.status = InviteStatus.USED;
+        }
+    }
+
+    public boolean hasUsageLimit() {
+        return this.maxUses != null;
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
@@ -63,7 +63,7 @@ public class RoomInvite extends BaseEntity {
     }
 
     public boolean isUsable() {
-        if (status == InviteStatu.EXPIRED) return false;
+        if (status == InviteStatus.EXPIRED) return false;
         return expiresAt == null || !expiresAt.isBefore(Instant.now());
     }
 

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomInvite.java
@@ -63,7 +63,7 @@ public class RoomInvite extends BaseEntity {
     }
 
     public boolean isUsable() {
-        if (status == InviteStatus.EXPIRED) return false;
+        if (status == InviteStatu.EXPIRED) return false;
         return expiresAt == null || !expiresAt.isBefore(Instant.now());
     }
 

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomParticipant.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomParticipant.java
@@ -30,7 +30,7 @@ public class RoomParticipant {
     @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_participant_member"))
     private Member member;
 
-    @Column(name = "session_id", optional = false)
+    @Column(name = "session_id")
     private String sessionId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/RoomParticipant.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/RoomParticipant.java
@@ -30,6 +30,9 @@ public class RoomParticipant {
     @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_participant_member"))
     private Member member;
 
+    @Column(name = "session_id", optional = false)
+    private String sessionId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", length = 20, nullable = false)
     private ParticipantRole role;

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/enums/InviteStatus.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/enums/InviteStatus.java
@@ -2,5 +2,6 @@ package com.writingboard.server.domain.meeting.entity.enums;
 
 public enum InviteStatus {
     ACTIVE,
-    EXPIRED // 만료
+    EXPIRED, // 만료
+    USED     // 사용 완료
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/enums/InviteStatus.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/enums/InviteStatus.java
@@ -2,6 +2,5 @@ package com.writingboard.server.domain.meeting.entity.enums;
 
 public enum InviteStatus {
     ACTIVE,
-    EXPIRED, // 만료
-    USED     // 사용 완료
+    EXPIRED // 만료
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/enums/SavePolicy.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/enums/SavePolicy.java
@@ -1,0 +1,5 @@
+package com.writingboard.server.domain.meeting.entity.enums;
+
+public enum SavePolicy {
+    OVERWRITE, NEW_COPY
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/enums/SnapshotTriggerType.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/enums/SnapshotTriggerType.java
@@ -1,0 +1,7 @@
+package com.writingboard.server.domain.meeting.entity.enums;
+
+public enum SnapshotTriggerType {
+    AUTO,
+    MANUAL,
+    ERROR
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MeetingErrorCode {
     // Team
-    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_001", "팀을 찾을) 수 없습니다"),
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_001", "팀을 찾을 수 없습니다"),
     NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "TEAM_002", "팀 멤버가 아닙니다"),
 
     // Room
@@ -24,6 +24,17 @@ public enum MeetingErrorCode {
     // Invite
     INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITE_001", "초대를 찾을 수 없습니다"),
     INVITE_EXPIRED(HttpStatus.BAD_REQUEST, "INVITE_002", "만료된 초대입니다"),
+    INVITE_USAGE_EXCEEDED(HttpStatus.BAD_REQUEST, "INVITE_003", "초대 링크 사용 횟수를 초과했습니다"),
+
+    // Asset
+    ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "ASSET_001", "자료를 찾을 수 없습니다"),
+
+    // Canvas
+    CANVAS_NOT_FOUND(HttpStatus.NOT_FOUND, "CANVAS_001", "캔버스 데이터를 찾을 수 없습니다"),
+    SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "CANVAS_002", "스냅샷을 찾을 수 없습니다"),
+
+    // Permission
+    VIEWER_NOT_ALLOWED(HttpStatus.FORBIDDEN, "PERMISSION_001", "뷰어는 이 작업을 수행할 수 없습니다"),
 
     // Auth
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_001", "권한이 없습니다"),

--- a/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingErrorCode.java
@@ -24,7 +24,6 @@ public enum MeetingErrorCode {
     // Invite
     INVITE_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITE_001", "초대를 찾을 수 없습니다"),
     INVITE_EXPIRED(HttpStatus.BAD_REQUEST, "INVITE_002", "만료된 초대입니다"),
-    INVITE_USAGE_EXCEEDED(HttpStatus.BAD_REQUEST, "INVITE_003", "초대 링크 사용 횟수를 초과했습니다"),
 
     // Asset
     ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "ASSET_001", "자료를 찾을 수 없습니다"),

--- a/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingErrorCode.java
@@ -6,7 +6,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ErrorCode {
+public enum MeetingErrorCode {
+    // Team
+    TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_001", "팀을 찾을) 수 없습니다"),
+    NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "TEAM_002", "팀 멤버가 아닙니다"),
 
     // Room
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM_001", "회의실을 찾을 수 없습니다"),

--- a/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingException.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/exception/MeetingException.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 @Getter
 public class MeetingException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final MeetingErrorCode meetingErrorCode;
 
-    public MeetingException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+    public MeetingException(MeetingErrorCode meetingErrorCode) {
+        super(meetingErrorCode.getMessage());
+        this.meetingErrorCode = meetingErrorCode;
     }
 
-    public MeetingException(ErrorCode errorCode, String message) {
+    public MeetingException(MeetingErrorCode meetingErrorCode, String message) {
         super(message);
-        this.errorCode = errorCode;
+        this.meetingErrorCode = meetingErrorCode;
     }
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/repository/CanvasPageRepository.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/repository/CanvasPageRepository.java
@@ -1,0 +1,16 @@
+package com.writingboard.server.domain.meeting.repository;
+
+import com.writingboard.server.domain.meeting.entity.CanvasPage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CanvasPageRepository extends JpaRepository<CanvasPage, Long> {
+
+    Optional<CanvasPage> findByRoomAssetIdAndPageIndex(Long roomAssetId, Integer pageIndex);
+
+    List<CanvasPage> findByRoomAssetId(Long roomAssetId);
+
+    boolean existsByRoomAssetIdAndPageIndex(Long roomAssetId, Integer pageIndex);
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/repository/CanvasSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/repository/CanvasSnapshotRepository.java
@@ -1,0 +1,16 @@
+package com.writingboard.server.domain.meeting.repository;
+
+import com.writingboard.server.domain.meeting.entity.CanvasSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CanvasSnapshotRepository extends JpaRepository<CanvasSnapshot, Long> {
+
+    Optional<CanvasSnapshot> findTopByRoomAssetIdAndPageIndexOrderByCreatedAtDesc(Long roomAssetId, Integer pageIndex);
+
+    List<CanvasSnapshot> findByRoomAssetIdAndPageIndexOrderByCreatedAtDesc(Long roomAssetId, Integer pageIndex);
+
+    List<CanvasSnapshot> findByRoomAssetIdOrderByCreatedAtDesc(Long roomAssetId);
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/repository/RoomAssetRepository.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/repository/RoomAssetRepository.java
@@ -1,0 +1,34 @@
+package com.writingboard.server.domain.meeting.repository;
+
+import com.writingboard.server.domain.meeting.entity.RoomAsset;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoomAssetRepository extends JpaRepository<RoomAsset, Long> {
+
+    List<RoomAsset> findByRoomId(Long roomId);
+
+    @Query("SELECT ra FROM RoomAsset ra WHERE ra.room.roomUuid = :roomUuid")
+    List<RoomAsset> findByRoomUuid(@Param("roomUuid") String roomUuid);
+
+    Optional<RoomAsset> findByIdAndRoomId(Long id, Long roomId);
+
+    @Query("SELECT ra FROM RoomAsset ra WHERE ra.id = :id AND ra.room.roomUuid = :roomUuid")
+    Optional<RoomAsset> findByIdAndRoomUuid(@Param("id") Long id, @Param("roomUuid") String roomUuid);
+
+    @Modifying
+    @Query("UPDATE RoomAsset ra SET ra.isActive = false WHERE ra.room.id = :roomId")
+    void deactivateAllByRoomId(@Param("roomId") Long roomId);
+
+    @Modifying
+    @Query("UPDATE RoomAsset ra SET ra.isActive = false WHERE ra.room.roomUuid = :roomUuid")
+    void deactivateAllByRoomUuid(@Param("roomUuid") String roomUuid);
+
+    @Query("SELECT ra FROM RoomAsset ra WHERE ra.room.roomUuid = :roomUuid AND ra.isActive = true")
+    Optional<RoomAsset> findActiveByRoomUuid(@Param("roomUuid") String roomUuid);
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowRedisPublisher.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class FollowRedisPublisher {
+public class CanvasFollowRedisPublisher {
 
     private static final String CHANNEL_PREFIX = "follow:room:";
 

--- a/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowService.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class FollowService {
+public class CanvasFollowService {
 
     private static final String VIEWING_STATE_KEY_PREFIX = "viewing:room:";
     private static final String FOLLOW_KEY_PREFIX = "follow:member:";
@@ -35,7 +35,7 @@ public class FollowService {
     private final RoomRepository roomRepository;
     private final RoomParticipantRepository participantRepository;
     private final RoomAssetRepository roomAssetRepository;
-    private final FollowRedisPublisher followRedisPublisher;
+    private final CanvasFollowRedisPublisher canvasFollowRedisPublisher;
     private final RedisTemplate<String, String> stringRedisTemplate;
 
     public void updateViewingState(Long memberId, String roomUuid, Long roomAssetId, Integer pageIndex) {
@@ -52,7 +52,7 @@ public class FollowService {
                 roomAssetId,
                 pageIndex
         );
-        followRedisPublisher.publish(roomUuid, state);
+        canvasFollowRedisPublisher.publish(roomUuid, state);
 
         log.debug("Updated viewing state: memberId={}, roomUuid={}, assetId={}, page={}",
                 memberId, roomUuid, roomAssetId, pageIndex);

--- a/src/main/java/com/writingboard/server/domain/meeting/service/CanvasService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/CanvasService.java
@@ -1,0 +1,153 @@
+package com.writingboard.server.domain.meeting.service;
+
+import com.writingboard.server.domain.meeting.dto.request.CanvasUpdateRequest;
+import com.writingboard.server.domain.meeting.dto.response.CanvasPageResponse;
+import com.writingboard.server.domain.meeting.dto.response.CanvasSnapshotResponse;
+import com.writingboard.server.domain.meeting.entity.CanvasPage;
+import com.writingboard.server.domain.meeting.entity.CanvasSnapshot;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.RoomAsset;
+import com.writingboard.server.domain.meeting.entity.RoomParticipant;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.entity.enums.SnapshotTriggerType;
+import com.writingboard.server.domain.meeting.exception.MeetingErrorCode;
+import com.writingboard.server.domain.meeting.exception.MeetingException;
+import com.writingboard.server.domain.meeting.repository.CanvasPageRepository;
+import com.writingboard.server.domain.meeting.repository.CanvasSnapshotRepository;
+import com.writingboard.server.domain.meeting.repository.RoomAssetRepository;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CanvasService {
+
+    private final CanvasPageRepository canvasPageRepository;
+    private final CanvasSnapshotRepository canvasSnapshotRepository;
+    private final RoomAssetRepository roomAssetRepository;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+
+    public CanvasPageResponse getCanvasPage(Long memberId, String roomUuid, Long roomAssetId, int pageIndex) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipant(room, memberId);
+
+        RoomAsset roomAsset = roomAssetRepository.findByIdAndRoomUuid(roomAssetId, roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ASSET_NOT_FOUND));
+
+        CanvasPage canvasPage = canvasPageRepository.findByRoomAssetIdAndPageIndex(roomAsset.getId(), pageIndex)
+                .orElse(null);
+
+        if (canvasPage == null) {
+            return CanvasPageResponse.empty(roomAssetId, pageIndex);
+        }
+
+        return CanvasPageResponse.from(canvasPage);
+    }
+
+    @Transactional
+    public CanvasPageResponse updateCanvasPage(Long memberId, String roomUuid, Long roomAssetId, int pageIndex, CanvasUpdateRequest request) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipantWithWritePermission(room, memberId);
+
+        RoomAsset roomAsset = roomAssetRepository.findByIdAndRoomUuid(roomAssetId, roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ASSET_NOT_FOUND));
+
+        byte[] rawData = null;
+        if (request.getRawData() != null) {
+            rawData = Base64.getDecoder().decode(request.getRawData());
+        }
+
+        CanvasPage canvasPage = canvasPageRepository.findByRoomAssetIdAndPageIndex(roomAsset.getId(), pageIndex)
+                .orElseGet(() -> {
+                    CanvasPage newPage = CanvasPage.create(roomAsset, pageIndex);
+                    return canvasPageRepository.save(newPage);
+                });
+
+        canvasPage.updateData(rawData);
+
+        if (request.isCreateSnapshot()) {
+            SnapshotTriggerType triggerType = request.getSnapshotTriggerType() != null
+                    ? request.getSnapshotTriggerType()
+                    : SnapshotTriggerType.MANUAL;
+            createSnapshotInternal(roomAsset, pageIndex, rawData, triggerType);
+        }
+
+        return CanvasPageResponse.from(canvasPage);
+    }
+
+    @Transactional
+    public CanvasSnapshotResponse createSnapshot(Long memberId, String roomUuid, Long roomAssetId, int pageIndex, SnapshotTriggerType triggerType) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipantWithWritePermission(room, memberId);
+
+        RoomAsset roomAsset = roomAssetRepository.findByIdAndRoomUuid(roomAssetId, roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ASSET_NOT_FOUND));
+
+        CanvasPage canvasPage = canvasPageRepository.findByRoomAssetIdAndPageIndex(roomAsset.getId(), pageIndex)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.CANVAS_NOT_FOUND));
+
+        CanvasSnapshot snapshot = createSnapshotInternal(roomAsset, pageIndex, canvasPage.getRawData(), triggerType);
+        return CanvasSnapshotResponse.from(snapshot);
+    }
+
+    @Transactional
+    public CanvasPageResponse restoreFromSnapshot(Long memberId, String roomUuid, Long roomAssetId, int pageIndex) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipantWithWritePermission(room, memberId);
+
+        RoomAsset roomAsset = roomAssetRepository.findByIdAndRoomUuid(roomAssetId, roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ASSET_NOT_FOUND));
+
+        CanvasSnapshot snapshot = canvasSnapshotRepository.findTopByRoomAssetIdAndPageIndexOrderByCreatedAtDesc(roomAsset.getId(), pageIndex)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.SNAPSHOT_NOT_FOUND));
+
+        CanvasPage canvasPage = canvasPageRepository.findByRoomAssetIdAndPageIndex(roomAsset.getId(), pageIndex)
+                .orElseGet(() -> {
+                    CanvasPage newPage = CanvasPage.create(roomAsset, pageIndex);
+                    return canvasPageRepository.save(newPage);
+                });
+
+        canvasPage.updateData(snapshot.getStrokeData());
+        return CanvasPageResponse.from(canvasPage);
+    }
+
+    private CanvasSnapshot createSnapshotInternal(RoomAsset roomAsset, int pageIndex, byte[] data, SnapshotTriggerType triggerType) {
+        CanvasSnapshot snapshot = CanvasSnapshot.create(roomAsset, pageIndex, data, triggerType);
+        return canvasSnapshotRepository.save(snapshot);
+    }
+
+    private Room getRoomByUuid(String roomUuid) {
+        return roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ROOM_NOT_FOUND));
+    }
+
+    private void validateParticipant(Room room, Long memberId) {
+        boolean isParticipant = participantRepository
+                .existsByRoomIdAndMemberIdAndState(room.getId(), memberId, ParticipantState.JOINED);
+        if (!isParticipant) {
+            throw new MeetingException(MeetingErrorCode.NOT_PARTICIPANT);
+        }
+    }
+
+    private void validateParticipantWithWritePermission(Room room, Long memberId) {
+        RoomParticipant participant = participantRepository
+                .findByRoomIdAndMemberId(room.getId(), memberId)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_PARTICIPANT));
+
+        if (participant.getState() != ParticipantState.JOINED) {
+            throw new MeetingException(MeetingErrorCode.NOT_PARTICIPANT);
+        }
+
+        if (participant.getRole() == ParticipantRole.VIEWER) {
+            throw new MeetingException(MeetingErrorCode.VIEWER_NOT_ALLOWED);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/service/FollowRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/FollowRedisPublisher.java
@@ -1,0 +1,28 @@
+package com.writingboard.server.domain.meeting.service;
+
+import com.writingboard.server.domain.meeting.dto.FollowStateDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FollowRedisPublisher {
+
+    private static final String CHANNEL_PREFIX = "follow:room:";
+
+    private final RedisTemplate<String, FollowStateDto> followRedisTemplate;
+
+    public void publish(String roomUuid, FollowStateDto state) {
+        String channel = CHANNEL_PREFIX + roomUuid;
+
+        try {
+            followRedisTemplate.convertAndSend(channel, state);
+            log.debug("Follow state published: channel={}, memberId={}", channel, state.getMemberId());
+        } catch (Exception e) {
+            log.error("Failed to publish follow state: channel={}", channel, e);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/service/FollowRedisSubscriber.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/FollowRedisSubscriber.java
@@ -1,0 +1,47 @@
+package com.writingboard.server.domain.meeting.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.writingboard.server.domain.meeting.dto.FollowStateDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FollowRedisSubscriber implements MessageListener {
+
+    private static final String CHANNEL_PREFIX = "follow:room:";
+    private static final String TOPIC_PREFIX = "/topic/room/";
+    private static final String TOPIC_SUFFIX = "/follow";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String body = new String(message.getBody());
+
+            FollowStateDto followState = objectMapper.readValue(body, FollowStateDto.class);
+            String roomUuid = extractRoomUuid(channel);
+
+            String destination = TOPIC_PREFIX + roomUuid + TOPIC_SUFFIX;
+            messagingTemplate.convertAndSend(destination, followState);
+
+            log.debug("Follow state sent to clients: destination={}, memberId={}",
+                    destination, followState.getMemberId());
+
+        } catch (Exception e) {
+            log.error("Failed to process follow message from Redis", e);
+        }
+    }
+
+    private String extractRoomUuid(String channel) {
+        return channel.replace(CHANNEL_PREFIX, "");
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/service/FollowService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/FollowService.java
@@ -1,0 +1,160 @@
+package com.writingboard.server.domain.meeting.service;
+
+import com.writingboard.server.domain.meeting.dto.FollowStateDto;
+import com.writingboard.server.domain.meeting.dto.response.ParticipantViewingResponse;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.RoomAsset;
+import com.writingboard.server.domain.meeting.entity.RoomParticipant;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.exception.MeetingErrorCode;
+import com.writingboard.server.domain.meeting.exception.MeetingException;
+import com.writingboard.server.domain.meeting.repository.RoomAssetRepository;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowService {
+
+    private static final String VIEWING_STATE_KEY_PREFIX = "viewing:room:";
+    private static final String FOLLOW_KEY_PREFIX = "follow:member:";
+    private static final Duration VIEWING_STATE_TTL = Duration.ofMinutes(30);
+
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+    private final RoomAssetRepository roomAssetRepository;
+    private final FollowRedisPublisher followRedisPublisher;
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    public void updateViewingState(Long memberId, String roomUuid, Long roomAssetId, Integer pageIndex) {
+        Room room = getRoomByUuid(roomUuid);
+        RoomParticipant participant = validateParticipant(room, memberId);
+
+        String key = VIEWING_STATE_KEY_PREFIX + roomUuid + ":" + memberId;
+        String value = roomAssetId + ":" + pageIndex;
+        stringRedisTemplate.opsForValue().set(key, value, VIEWING_STATE_TTL);
+
+        FollowStateDto state = FollowStateDto.of(
+                memberId,
+                participant.getMember().getName(),
+                roomAssetId,
+                pageIndex
+        );
+        followRedisPublisher.publish(roomUuid, state);
+
+        log.debug("Updated viewing state: memberId={}, roomUuid={}, assetId={}, page={}",
+                memberId, roomUuid, roomAssetId, pageIndex);
+    }
+
+    @Transactional
+    public void startFollow(Long memberId, String roomUuid, Long targetMemberId) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipant(room, memberId);
+
+        RoomParticipant target = participantRepository.findByRoomIdAndMemberId(room.getId(), targetMemberId)
+                .filter(p -> p.getState() == ParticipantState.JOINED)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEMBER_NOT_FOUND));
+
+        String followKey = FOLLOW_KEY_PREFIX + memberId + ":room:" + roomUuid;
+        stringRedisTemplate.opsForValue().set(followKey, targetMemberId.toString(), VIEWING_STATE_TTL);
+
+        log.info("Member {} started following {} in room {}", memberId, targetMemberId, roomUuid);
+    }
+
+    @Transactional
+    public void stopFollow(Long memberId, String roomUuid) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipant(room, memberId);
+
+        String followKey = FOLLOW_KEY_PREFIX + memberId + ":room:" + roomUuid;
+        stringRedisTemplate.delete(followKey);
+
+        log.info("Member {} stopped following in room {}", memberId, roomUuid);
+    }
+
+    public Long getFollowingTarget(Long memberId, String roomUuid) {
+        String followKey = FOLLOW_KEY_PREFIX + memberId + ":room:" + roomUuid;
+        String targetIdStr = stringRedisTemplate.opsForValue().get(followKey);
+
+        if (targetIdStr == null) {
+            return null;
+        }
+
+        return Long.parseLong(targetIdStr);
+    }
+
+    public List<ParticipantViewingResponse> getParticipantsViewing(Long memberId, String roomUuid) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipant(room, memberId);
+
+        List<RoomParticipant> activeParticipants = participantRepository
+                .findByRoomIdAndState(room.getId(), ParticipantState.JOINED);
+
+        Map<Long, RoomAsset> activeAssets = roomAssetRepository.findByRoomUuid(roomUuid).stream()
+                .filter(RoomAsset::getIsActive)
+                .collect(Collectors.toMap(RoomAsset::getId, a -> a, (a, b) -> a));
+
+        return activeParticipants.stream()
+                .map(participant -> {
+                    Long participantMemberId = participant.getMember().getId();
+                    String key = VIEWING_STATE_KEY_PREFIX + roomUuid + ":" + participantMemberId;
+                    String value = stringRedisTemplate.opsForValue().get(key);
+
+                    Long roomAssetId = null;
+                    Integer pageIndex = null;
+                    String assetName = null;
+
+                    if (value != null) {
+                        String[] parts = value.split(":");
+                        if (parts.length == 2) {
+                            roomAssetId = Long.parseLong(parts[0]);
+                            pageIndex = Integer.parseInt(parts[1]);
+
+                            RoomAsset asset = activeAssets.get(roomAssetId);
+                            if (asset != null && asset.getTeamAsset() != null) {
+                                assetName = asset.getTeamAsset().getName();
+                            }
+                        }
+                    }
+
+                    return ParticipantViewingResponse.builder()
+                            .memberId(participantMemberId)
+                            .memberName(participant.getMember().getName())
+                            .role(participant.getRole())
+                            .roomAssetId(roomAssetId)
+                            .assetName(assetName)
+                            .pageIndex(pageIndex)
+                            .build();
+                })
+                .toList();
+    }
+
+    private Room getRoomByUuid(String roomUuid) {
+        return roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ROOM_NOT_FOUND));
+    }
+
+    private RoomParticipant validateParticipant(Room room, Long memberId) {
+        RoomParticipant participant = participantRepository
+                .findByRoomIdAndMemberId(room.getId(), memberId)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_PARTICIPANT));
+
+        if (participant.getState() != ParticipantState.JOINED) {
+            throw new MeetingException(MeetingErrorCode.NOT_PARTICIPANT);
+        }
+
+        return participant;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/service/InviteTokenRedisService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/InviteTokenRedisService.java
@@ -17,7 +17,7 @@ public class InviteTokenRedisService {
     private static final String KEY_PREFIX = "invite:";
 
     /**
-     * 초대 토큰을 Redis에 저장 (TTL 적용)
+     * 초대 토큰을 Redis에 저장 (TTL : default 5분)
      *
      * @param inviteToken 초대 토큰
      * @param roomUuid    회의실 UUID

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomAssetService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomAssetService.java
@@ -1,0 +1,154 @@
+package com.writingboard.server.domain.meeting.service;
+
+import com.writingboard.server.domain.meeting.dto.request.LoadPersonalAssetRequest;
+import com.writingboard.server.domain.meeting.dto.request.LoadTeamAssetRequest;
+import com.writingboard.server.domain.meeting.dto.request.PageChangeRequest;
+import com.writingboard.server.domain.meeting.dto.response.RoomAssetResponse;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.RoomAsset;
+import com.writingboard.server.domain.meeting.entity.RoomParticipant;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.entity.enums.SavePolicy;
+import com.writingboard.server.domain.meeting.exception.MeetingErrorCode;
+import com.writingboard.server.domain.meeting.exception.MeetingException;
+import com.writingboard.server.domain.meeting.repository.RoomAssetRepository;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.personal.entity.PersonalAsset;
+import com.writingboard.server.domain.personal.service.PersonalAssetService;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamAsset;
+import com.writingboard.server.domain.team.entity.enums.AssetSourceType;
+import com.writingboard.server.domain.team.entity.enums.AssetStatus;
+import com.writingboard.server.domain.team.repository.TeamAssetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomAssetService {
+
+    private final RoomAssetRepository roomAssetRepository;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+    private final TeamAssetRepository teamAssetRepository;
+    private final MemberRepository memberRepository;
+    private final PersonalAssetService personalAssetService;
+
+    @Transactional
+    public RoomAssetResponse loadTeamAsset(Long memberId, String roomUuid, LoadTeamAssetRequest request) {
+        Room room = getRoomByUuid(roomUuid);
+        RoomParticipant participant = validateParticipantWithWritePermission(room, memberId);
+        Member member = participant.getMember();
+
+        TeamAsset teamAsset = teamAssetRepository.findByIdAndTeamIdAndStatus(
+                        request.getTeamAssetId(), room.getTeam().getId(), AssetStatus.ACTIVE)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ASSET_NOT_FOUND));
+
+        SavePolicy savePolicy = request.getSavePolicy() != null ? request.getSavePolicy() : SavePolicy.OVERWRITE;
+        RoomAsset roomAsset = RoomAsset.createFromTeamAsset(room, teamAsset, member, savePolicy);
+
+        roomAssetRepository.save(roomAsset);
+        return RoomAssetResponse.from(roomAsset);
+    }
+
+    @Transactional
+    public RoomAssetResponse loadPersonalAsset(Long memberId, String roomUuid, LoadPersonalAssetRequest request) {
+        Room room = getRoomByUuid(roomUuid);
+        RoomParticipant participant = validateParticipantWithWritePermission(room, memberId);
+        Member member = participant.getMember();
+        Team team = room.getTeam();
+
+        PersonalAsset personalAsset = personalAssetService.getAssetEntity(request.getPersonalAssetId());
+
+        if (!personalAsset.isOwnedBy(memberId)) {
+            throw new MeetingException(MeetingErrorCode.FORBIDDEN);
+        }
+
+        TeamAsset teamAsset = TeamAsset.createImported(
+                team,
+                member,
+                personalAsset.getType(),
+                personalAsset.getName(),
+                personalAsset.getId()
+        );
+        teamAssetRepository.save(teamAsset);
+
+        SavePolicy savePolicy = request.getSavePolicy() != null ? request.getSavePolicy() : SavePolicy.OVERWRITE;
+        RoomAsset roomAsset = RoomAsset.createFromTeamAsset(room, teamAsset, member, savePolicy);
+
+        roomAssetRepository.save(roomAsset);
+        return RoomAssetResponse.from(roomAsset);
+    }
+
+    public List<RoomAssetResponse> getRoomAssets(Long memberId, String roomUuid) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipant(room, memberId);
+
+        return roomAssetRepository.findByRoomUuid(roomUuid).stream()
+                .map(RoomAssetResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public RoomAssetResponse activateAsset(Long memberId, String roomUuid, Long roomAssetId) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipantWithWritePermission(room, memberId);
+
+        RoomAsset roomAsset = roomAssetRepository.findByIdAndRoomUuid(roomAssetId, roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ASSET_NOT_FOUND));
+
+        roomAssetRepository.deactivateAllByRoomUuid(roomUuid);
+        roomAsset.activate();
+
+        return RoomAssetResponse.from(roomAsset);
+    }
+
+    @Transactional
+    public RoomAssetResponse changePage(Long memberId, String roomUuid, Long roomAssetId, PageChangeRequest request) {
+        Room room = getRoomByUuid(roomUuid);
+        validateParticipantWithWritePermission(room, memberId);
+
+        RoomAsset roomAsset = roomAssetRepository.findByIdAndRoomUuid(roomAssetId, roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ASSET_NOT_FOUND));
+
+        roomAsset.changePage(request.getPageNumber());
+        return RoomAssetResponse.from(roomAsset);
+    }
+
+    private Room getRoomByUuid(String roomUuid) {
+        return roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ROOM_NOT_FOUND));
+    }
+
+    private void validateParticipant(Room room, Long memberId) {
+        boolean isParticipant = participantRepository
+                .existsByRoomIdAndMemberIdAndState(room.getId(), memberId, ParticipantState.JOINED);
+        if (!isParticipant) {
+            throw new MeetingException(MeetingErrorCode.NOT_PARTICIPANT);
+        }
+    }
+
+    private RoomParticipant validateParticipantWithWritePermission(Room room, Long memberId) {
+        RoomParticipant participant = participantRepository
+                .findByRoomIdAndMemberId(room.getId(), memberId)
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_PARTICIPANT));
+
+        if (participant.getState() != ParticipantState.JOINED) {
+            throw new MeetingException(MeetingErrorCode.NOT_PARTICIPANT);
+        }
+
+        if (participant.getRole() == ParticipantRole.VIEWER) {
+            throw new MeetingException(MeetingErrorCode.VIEWER_NOT_ALLOWED);
+        }
+
+        return participant;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomInviteService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomInviteService.java
@@ -4,10 +4,9 @@ import com.writingboard.server.domain.meeting.dto.request.InviteLinkRequest;
 import com.writingboard.server.domain.meeting.dto.response.InviteLinkResponse;
 import com.writingboard.server.domain.meeting.entity.Room;
 import com.writingboard.server.domain.meeting.entity.RoomInvite;
-import com.writingboard.server.domain.meeting.entity.enums.InviteStatus;
 import com.writingboard.server.domain.meeting.entity.enums.InviteType;
 import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
-import com.writingboard.server.domain.meeting.exception.ErrorCode;
+import com.writingboard.server.domain.meeting.exception.MeetingErrorCode;
 import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.meeting.repository.RoomInviteRepository;
 import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
@@ -62,24 +61,24 @@ public class RoomInviteService {
 
     private Room getRoomByUuid(String roomUuid) {
         return roomRepository.findByRoomUuid(roomUuid)
-                .orElseThrow(() -> new MeetingException(ErrorCode.ROOM_NOT_FOUND));
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ROOM_NOT_FOUND));
     }
 
     private Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MeetingException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEMBER_NOT_FOUND));
     }
 
     private Member getMemberByUserName(String username) {
         return memberRepository.findByName(username)
-                .orElseThrow(() -> new MeetingException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEMBER_NOT_FOUND));
     }
 
     private void validateParticipant(Room room, Long memberId) {
         boolean isParticipant = participantRepository
                 .existsByRoomIdAndMemberIdAndState(room.getId(), memberId, ParticipantState.JOINED);
         if (!isParticipant) {
-            throw new MeetingException(ErrorCode.NOT_PARTICIPANT);
+            throw new MeetingException(MeetingErrorCode.NOT_PARTICIPANT);
         }
     }
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
@@ -6,17 +6,20 @@ import com.writingboard.server.domain.meeting.dto.response.*;
 import com.writingboard.server.domain.meeting.entity.Room;
 import com.writingboard.server.domain.meeting.entity.RoomInvite;
 import com.writingboard.server.domain.meeting.entity.RoomParticipant;
-import com.writingboard.server.domain.meeting.entity.enums.InviteType;
 import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
 import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
 import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
-import com.writingboard.server.domain.meeting.exception.ErrorCode;
+import com.writingboard.server.domain.meeting.exception.MeetingErrorCode;
 import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.meeting.repository.RoomInviteRepository;
 import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
 import com.writingboard.server.domain.meeting.repository.RoomRepository;
 import com.writingboard.server.domain.member.entity.Member;
 import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,6 +36,8 @@ import java.util.UUID;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
     private final RoomParticipantRepository participantRepository;
     private final RoomInviteRepository inviteRepository;
     private final MemberRepository memberRepository;
@@ -46,12 +51,21 @@ public class RoomService {
     public RoomCreateResponse createRoom(Long memberId, RoomCreateRequest request) {
         Member host = getMemberById(memberId);
 
+        Team team = teamRepository.findById(request.getTeamId())
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.TEAM_NOT_FOUND));
+
+        // 팀 멤버 검증
+        boolean isTeamMember = teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(team.getId(), host.getId(), TeamMemberStatus.ACTIVE);
+        if (!isTeamMember) {
+            throw new MeetingException(MeetingErrorCode.NOT_TEAM_MEMBER);
+        }
+
         String roomUuid = UUID.randomUUID().toString();
         String passwordHash = request.getPassword() != null
                 ? passwordEncoder.encode(request.getPassword())
                 : null;
 
-        Room room = Room.create(roomUuid, request.getTitle(), host, passwordHash);
+        Room room = Room.create(roomUuid, request.getTitle(), host, team, passwordHash);
         room.join(host, ParticipantRole.HOST);
 
         roomRepository.save(room);
@@ -111,7 +125,7 @@ public class RoomService {
         if (room.getPasswordHash() != null) {
             if (request == null || request.getPassword() == null ||
                     !passwordEncoder.matches(request.getPassword(), room.getPasswordHash())) {
-                throw new MeetingException(ErrorCode.INVALID_PASSWORD);
+                throw new MeetingException(MeetingErrorCode.INVALID_PASSWORD);
             }
         }
 
@@ -137,13 +151,13 @@ public class RoomService {
         } else {
             // 2차: DB Fallback (Redis 장애 또는 캐시 미스 대비)
             RoomInvite invite = inviteRepository.findByInviteToken(inviteToken)
-                    .orElseThrow(() -> new MeetingException(ErrorCode.INVITE_NOT_FOUND));
+                    .orElseThrow(() -> new MeetingException(MeetingErrorCode.INVITE_NOT_FOUND));
 
             // 만료 체크 및 상태 업데이트
             invite.checkAndExpire();
 
             if (!invite.isUsable()) {
-                throw new MeetingException(ErrorCode.INVITE_EXPIRED);
+                throw new MeetingException(MeetingErrorCode.INVITE_EXPIRED);
             }
 
             room = invite.getRoom();
@@ -154,7 +168,7 @@ public class RoomService {
         // 비밀번호 검증
         if (room.getPasswordHash() != null) {
             if (password == null || !passwordEncoder.matches(password, room.getPasswordHash())) {
-                throw new MeetingException(ErrorCode.INVALID_PASSWORD);
+                throw new MeetingException(MeetingErrorCode.INVALID_PASSWORD);
             }
         }
 
@@ -183,15 +197,15 @@ public class RoomService {
 
         RoomParticipant requester = participantRepository
                 .findByRoomIdAndMemberId(room.getId(), requesterId)
-                .orElseThrow(() -> new MeetingException(ErrorCode.NOT_PARTICIPANT));
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.NOT_PARTICIPANT));
 
         if (requester.getRole() != ParticipantRole.HOST &&
                 requester.getRole() != ParticipantRole.MODERATOR) {
-            throw new MeetingException(ErrorCode.FORBIDDEN);
+            throw new MeetingException(MeetingErrorCode.FORBIDDEN);
         }
 
         if (room.getHost().getId().equals(targetMemberId)) {
-            throw new MeetingException(ErrorCode.CANNOT_KICK_HOST);
+            throw new MeetingException(MeetingErrorCode.CANNOT_KICK_HOST);
         }
 
         Member targetMember = getMemberById(targetMemberId);
@@ -200,23 +214,23 @@ public class RoomService {
 
     private Room getRoomByUuid(String roomUuid) {
         return roomRepository.findByRoomUuid(roomUuid)
-                .orElseThrow(() -> new MeetingException(ErrorCode.ROOM_NOT_FOUND));
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.ROOM_NOT_FOUND));
     }
 
     private Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MeetingException(ErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MeetingException(MeetingErrorCode.MEMBER_NOT_FOUND));
     }
 
     private void validateHost(Room room, Long memberId) {
         if (!room.getHost().getId().equals(memberId)) {
-            throw new MeetingException(ErrorCode.FORBIDDEN);
+            throw new MeetingException(MeetingErrorCode.FORBIDDEN);
         }
     }
 
     private void validateRoomOpen(Room room) {
         if (room.getStatus() != RoomStatus.OPEN) {
-            throw new MeetingException(ErrorCode.ROOM_CLOSED);
+            throw new MeetingException(MeetingErrorCode.ROOM_CLOSED);
         }
     }
 }

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
@@ -137,10 +137,12 @@ public class RoomService {
 
     /**
      * 초대 토큰으로 회의실 입장
+     * 팀 멤버가 아닌 경우 VIEWER 권한으로 입장
      */
     @Transactional
     public RoomJoinResponse joinRoomByInvite(Long memberId, String inviteToken, String password) {
         Room room;
+        RoomInvite invite = null;
 
         // Redis에서 조회
         String roomUuid = inviteTokenRedisService.getRoomUuid(inviteToken);
@@ -148,15 +150,20 @@ public class RoomService {
         if (roomUuid != null) {
             // Redis에 있음 → 유효한 초대 (Fast Path)
             room = getRoomByUuid(roomUuid);
+            // DB에서 초대 정보 조회 (사용 횟수 추적용)
+            invite = inviteRepository.findByInviteToken(inviteToken).orElse(null);
         } else {
             // 2차: DB Fallback (Redis 장애 또는 캐시 미스 대비)
-            RoomInvite invite = inviteRepository.findByInviteToken(inviteToken)
+            invite = inviteRepository.findByInviteToken(inviteToken)
                     .orElseThrow(() -> new MeetingException(MeetingErrorCode.INVITE_NOT_FOUND));
 
             // 만료 체크 및 상태 업데이트
             invite.checkAndExpire();
 
             if (!invite.isUsable()) {
+                if (invite.hasUsageLimit() && invite.getUsedCount() >= invite.getMaxUses()) {
+                    throw new MeetingException(MeetingErrorCode.INVITE_USAGE_EXCEEDED);
+                }
                 throw new MeetingException(MeetingErrorCode.INVITE_EXPIRED);
             }
 
@@ -173,7 +180,19 @@ public class RoomService {
         }
 
         Member member = getMemberById(memberId);
-        RoomParticipant participant = room.join(member, ParticipantRole.PARTICIPANT);
+
+        // 팀 멤버 여부 확인하여 역할 결정
+        boolean isTeamMember = teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(
+                room.getTeam().getId(), memberId, TeamMemberStatus.ACTIVE);
+
+        ParticipantRole role = isTeamMember ? ParticipantRole.PARTICIPANT : ParticipantRole.VIEWER;
+
+        RoomParticipant participant = room.join(member, role);
+
+        // 초대 사용 횟수 증가
+        if (invite != null) {
+            invite.use();
+        }
 
         return RoomJoinResponse.of(room, participant);
     }

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
@@ -116,6 +116,7 @@ public class RoomService {
 
     /**
      * 회의실 입장
+     * 재입장 시 기존 역할 유지 (HOST, MODERATOR 등)
      */
     @Transactional
     public RoomJoinResponse joinRoom(Long memberId, String roomUuid, RoomJoinRequest request) {
@@ -130,9 +131,22 @@ public class RoomService {
         }
 
         Member member = getMemberById(memberId);
-        RoomParticipant participant = room.join(member, ParticipantRole.PARTICIPANT);
 
-        return RoomJoinResponse.of(room, participant);
+        // 기존 참가 기록 확인
+        ParticipantRole roleToAssign = ParticipantRole.PARTICIPANT;
+        boolean isRejoining = participantRepository.findByRoomIdAndMemberId(room.getId(), memberId)
+                .isPresent();
+
+        if (isRejoining) {
+            // 재입장인 경우 기존 역할 유지를 위해 null 전달
+            // Room.join()의 rejoin() 로직에서 null이면 기존 role 유지
+            RoomParticipant participant = room.join(member, null);
+            return RoomJoinResponse.of(room, participant);
+        } else {
+            // 최초 입장인 경우 PARTICIPANT 권한 부여
+            RoomParticipant participant = room.join(member, roleToAssign);
+            return RoomJoinResponse.of(room, participant);
+        }
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/RoomService.java
@@ -116,7 +116,7 @@ public class RoomService {
 
     /**
      * 회의실 입장
-     * 재입장 시 기존 역할 유지 (HOST, MODERATOR 등)
+     * 재입장 시 기존 역할 유지
      */
     @Transactional
     public RoomJoinResponse joinRoom(Long memberId, String roomUuid, RoomJoinRequest request) {
@@ -156,28 +156,22 @@ public class RoomService {
     @Transactional
     public RoomJoinResponse joinRoomByInvite(Long memberId, String inviteToken, String password) {
         Room room;
-        RoomInvite invite = null;
 
         // Redis에서 조회
         String roomUuid = inviteTokenRedisService.getRoomUuid(inviteToken);
 
         if (roomUuid != null) {
-            // Redis에 있음 → 유효한 초대 (Fast Path)
+            // Redis에 있음
             room = getRoomByUuid(roomUuid);
-            // DB에서 초대 정보 조회 (사용 횟수 추적용)
-            invite = inviteRepository.findByInviteToken(inviteToken).orElse(null);
         } else {
-            // 2차: DB Fallback (Redis 장애 또는 캐시 미스 대비)
-            invite = inviteRepository.findByInviteToken(inviteToken)
+            // DB
+            RoomInvite invite = inviteRepository.findByInviteToken(inviteToken)
                     .orElseThrow(() -> new MeetingException(MeetingErrorCode.INVITE_NOT_FOUND));
 
             // 만료 체크 및 상태 업데이트
             invite.checkAndExpire();
 
             if (!invite.isUsable()) {
-                if (invite.hasUsageLimit() && invite.getUsedCount() >= invite.getMaxUses()) {
-                    throw new MeetingException(MeetingErrorCode.INVITE_USAGE_EXCEEDED);
-                }
                 throw new MeetingException(MeetingErrorCode.INVITE_EXPIRED);
             }
 
@@ -203,11 +197,6 @@ public class RoomService {
 
         RoomParticipant participant = room.join(member, role);
 
-        // 초대 사용 횟수 증가
-        if (invite != null) {
-            invite.use();
-        }
-
         return RoomJoinResponse.of(room, participant);
     }
 
@@ -222,7 +211,7 @@ public class RoomService {
     }
 
     /**
-     * 참여자 강제 퇴장 (호스트/모더레이터)
+     * 참여자 강제 퇴장
      */
     @Transactional
     public void kickParticipant(Long requesterId, String roomUuid, Long targetMemberId) {

--- a/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package com.writingboard.server.domain.member.repository;
 
 import com.writingboard.server.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/src/main/java/com/writingboard/server/domain/personal/controller/PersonalAssetController.java
+++ b/src/main/java/com/writingboard/server/domain/personal/controller/PersonalAssetController.java
@@ -1,0 +1,58 @@
+package com.writingboard.server.domain.personal.controller;
+
+import com.writingboard.server.domain.personal.dto.request.PersonalAssetCreateRequest;
+import com.writingboard.server.domain.personal.dto.response.PersonalAssetResponse;
+import com.writingboard.server.domain.personal.service.PersonalAssetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/personal-assets")
+@RequiredArgsConstructor
+@Tag(name = "Personal Asset", description = "개인 자료 관리 API")
+public class PersonalAssetController {
+
+    private final PersonalAssetService personalAssetService;
+
+    @PostMapping
+    @Operation(summary = "개인 자료 생성", description = "새로운 개인 자료를 생성합니다")
+    public ResponseEntity<PersonalAssetResponse> createAsset(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid PersonalAssetCreateRequest request) {
+        PersonalAssetResponse response = personalAssetService.createAsset(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "개인 자료 목록 조회", description = "본인의 개인 자료 목록을 조회합니다")
+    public ResponseEntity<Page<PersonalAssetResponse>> getAssets(
+            @AuthenticationPrincipal Long memberId,
+            Pageable pageable) {
+        return ResponseEntity.ok(personalAssetService.getAssets(memberId, pageable));
+    }
+
+    @GetMapping("/{assetId}")
+    @Operation(summary = "개인 자료 상세 조회", description = "개인 자료의 상세 정보를 조회합니다")
+    public ResponseEntity<PersonalAssetResponse> getAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long assetId) {
+        return ResponseEntity.ok(personalAssetService.getAsset(memberId, assetId));
+    }
+
+    @DeleteMapping("/{assetId}")
+    @Operation(summary = "개인 자료 삭제", description = "개인 자료를 삭제합니다")
+    public ResponseEntity<Void> deleteAsset(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long assetId) {
+        personalAssetService.deleteAsset(memberId, assetId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/personal/dto/request/PersonalAssetCreateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/personal/dto/request/PersonalAssetCreateRequest.java
@@ -1,0 +1,26 @@
+package com.writingboard.server.domain.personal.dto.request;
+
+import com.writingboard.server.domain.team.entity.enums.AssetType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PersonalAssetCreateRequest {
+
+    @NotBlank(message = "자료 이름은 필수입니다")
+    private String name;
+
+    @NotNull(message = "자료 타입은 필수입니다")
+    private AssetType type;
+
+    private String storageKey;
+
+    private Long sizeBytes;
+
+    private Integer totalPages;
+}

--- a/src/main/java/com/writingboard/server/domain/personal/dto/response/PersonalAssetResponse.java
+++ b/src/main/java/com/writingboard/server/domain/personal/dto/response/PersonalAssetResponse.java
@@ -1,0 +1,37 @@
+package com.writingboard.server.domain.personal.dto.response;
+
+import com.writingboard.server.domain.personal.entity.PersonalAsset;
+import com.writingboard.server.domain.team.entity.enums.AssetType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class PersonalAssetResponse {
+
+    private Long id;
+    private String name;
+    private AssetType type;
+    private String storageKey;
+    private Long sizeBytes;
+    private Integer totalPages;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public static PersonalAssetResponse from(PersonalAsset asset) {
+        return PersonalAssetResponse.builder()
+                .id(asset.getId())
+                .name(asset.getName())
+                .type(asset.getType())
+                .storageKey(asset.getStorageKey())
+                .sizeBytes(asset.getSizeBytes())
+                .totalPages(asset.getTotalPages())
+                .createdAt(asset.getCreatedAt())
+                .updatedAt(asset.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/personal/entity/PersonalAsset.java
+++ b/src/main/java/com/writingboard/server/domain/personal/entity/PersonalAsset.java
@@ -1,0 +1,75 @@
+package com.writingboard.server.domain.personal.entity;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.team.entity.enums.AssetType;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "personal_asset")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PersonalAsset extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "personal_asset_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(name = "fk_personal_asset_member"))
+    private Member member;
+
+    @Column(name = "name", length = 255, nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 20, nullable = false)
+    private AssetType type;
+
+    @Column(name = "storage_key", length = 500)
+    private String storageKey;
+
+    @Column(name = "size_bytes")
+    private Long sizeBytes;
+
+    @Column(name = "total_pages")
+    private Integer totalPages;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    public static PersonalAsset create(Member member, String name, AssetType type, String storageKey, Long sizeBytes, Integer totalPages) {
+        PersonalAsset asset = new PersonalAsset();
+        asset.member = member;
+        asset.name = name;
+        asset.type = type;
+        asset.storageKey = storageKey;
+        asset.sizeBytes = sizeBytes;
+        asset.totalPages = totalPages;
+        return asset;
+    }
+
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public boolean isOwnedBy(Long memberId) {
+        return this.member.getId().equals(memberId);
+    }
+
+    public void updateName(String name) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/personal/exception/PersonalErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/personal/exception/PersonalErrorCode.java
@@ -1,0 +1,16 @@
+package com.writingboard.server.domain.personal.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PersonalErrorCode {
+    ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "PERSONAL_001", "개인 자료를 찾을 수 없습니다"),
+    ASSET_ACCESS_DENIED(HttpStatus.FORBIDDEN, "PERSONAL_002", "본인의 자료만 접근할 수 있습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/writingboard/server/domain/personal/exception/PersonalException.java
+++ b/src/main/java/com/writingboard/server/domain/personal/exception/PersonalException.java
@@ -1,0 +1,19 @@
+package com.writingboard.server.domain.personal.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PersonalException extends RuntimeException {
+
+    private final PersonalErrorCode errorCode;
+
+    public PersonalException(PersonalErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public PersonalException(PersonalErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/personal/repository/PersonalAssetRepository.java
+++ b/src/main/java/com/writingboard/server/domain/personal/repository/PersonalAssetRepository.java
@@ -1,0 +1,17 @@
+package com.writingboard.server.domain.personal.repository;
+
+import com.writingboard.server.domain.personal.entity.PersonalAsset;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PersonalAssetRepository extends JpaRepository<PersonalAsset, Long> {
+
+    Page<PersonalAsset> findByMemberIdAndDeletedAtIsNull(Long memberId, Pageable pageable);
+
+    Optional<PersonalAsset> findByIdAndDeletedAtIsNull(Long id);
+
+    Optional<PersonalAsset> findByIdAndMemberIdAndDeletedAtIsNull(Long id, Long memberId);
+}

--- a/src/main/java/com/writingboard/server/domain/personal/service/PersonalAssetService.java
+++ b/src/main/java/com/writingboard/server/domain/personal/service/PersonalAssetService.java
@@ -1,0 +1,78 @@
+package com.writingboard.server.domain.personal.service;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.personal.dto.request.PersonalAssetCreateRequest;
+import com.writingboard.server.domain.personal.dto.response.PersonalAssetResponse;
+import com.writingboard.server.domain.personal.entity.PersonalAsset;
+import com.writingboard.server.domain.personal.exception.PersonalErrorCode;
+import com.writingboard.server.domain.personal.exception.PersonalException;
+import com.writingboard.server.domain.personal.repository.PersonalAssetRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PersonalAssetService {
+
+    private final PersonalAssetRepository personalAssetRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public PersonalAssetResponse createAsset(Long memberId, PersonalAssetCreateRequest request) {
+        Member member = getMemberById(memberId);
+
+        PersonalAsset asset = PersonalAsset.create(
+                member,
+                request.getName(),
+                request.getType(),
+                request.getStorageKey(),
+                request.getSizeBytes(),
+                request.getTotalPages()
+        );
+
+        personalAssetRepository.save(asset);
+        return PersonalAssetResponse.from(asset);
+    }
+
+    public Page<PersonalAssetResponse> getAssets(Long memberId, Pageable pageable) {
+        return personalAssetRepository.findByMemberIdAndDeletedAtIsNull(memberId, pageable)
+                .map(PersonalAssetResponse::from);
+    }
+
+    public PersonalAssetResponse getAsset(Long memberId, Long assetId) {
+        PersonalAsset asset = getAssetWithOwnershipCheck(assetId, memberId);
+        return PersonalAssetResponse.from(asset);
+    }
+
+    @Transactional
+    public void deleteAsset(Long memberId, Long assetId) {
+        PersonalAsset asset = getAssetWithOwnershipCheck(assetId, memberId);
+        asset.softDelete();
+    }
+
+    public PersonalAsset getAssetEntity(Long assetId) {
+        return personalAssetRepository.findByIdAndDeletedAtIsNull(assetId)
+                .orElseThrow(() -> new PersonalException(PersonalErrorCode.ASSET_NOT_FOUND));
+    }
+
+    private PersonalAsset getAssetWithOwnershipCheck(Long assetId, Long memberId) {
+        PersonalAsset asset = personalAssetRepository.findByIdAndDeletedAtIsNull(assetId)
+                .orElseThrow(() -> new PersonalException(PersonalErrorCode.ASSET_NOT_FOUND));
+
+        if (!asset.isOwnedBy(memberId)) {
+            throw new PersonalException(PersonalErrorCode.ASSET_ACCESS_DENIED);
+        }
+
+        return asset;
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new PersonalException(PersonalErrorCode.ASSET_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
 import com.writingboard.server.domain.chat.service.ChatRedisSubscriber;
+import com.writingboard.server.domain.meeting.dto.FollowStateDto;
+import com.writingboard.server.domain.meeting.service.FollowRedisSubscriber;
 import com.writingboard.server.domain.voice.dto.response.VoiceSignalDto;
 import com.writingboard.server.domain.voice.service.VoiceRedisSubscriber;
 import org.springframework.context.annotation.Bean;
@@ -22,7 +24,8 @@ public class RedisPubSubConfig {
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory redisConnectionFactory,
             ChatRedisSubscriber chatRedisSubscriber,
-            VoiceRedisSubscriber voiceRedisSubscriber) {
+            VoiceRedisSubscriber voiceRedisSubscriber,
+            FollowRedisSubscriber followRedisSubscriber) {
 
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
@@ -32,6 +35,9 @@ public class RedisPubSubConfig {
 
         // voice:room:* 패턴의 모든 채널 구독
         container.addMessageListener(voiceRedisSubscriber, new PatternTopic("voice:room:*"));
+
+        // follow:room:* 패턴의 모든 채널 구독
+        container.addMessageListener(followRedisSubscriber, new PatternTopic("follow:room:*"));
 
         return container;
     }
@@ -69,6 +75,26 @@ public class RedisPubSubConfig {
 
         Jackson2JsonRedisSerializer<VoiceSignalDto> serializer =
                 new Jackson2JsonRedisSerializer<>(objectMapper, VoiceSignalDto.class);
+
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, FollowStateDto> followRedisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, FollowStateDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        Jackson2JsonRedisSerializer<FollowStateDto> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, FollowStateDto.class);
 
         template.setValueSerializer(serializer);
         template.afterPropertiesSet();

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -30,8 +30,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleMeetingException(MeetingException e) {
         log.warn("MeetingException: {}", e.getMessage());
         return ResponseEntity
-                .status(e.getErrorCode().getStatus())
-                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+                .status(e.getMeetingErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getMeetingErrorCode().getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(ChatException.class)

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.writingboard.server.domain.auth.exception.AuthException;
 import com.writingboard.server.domain.chat.exception.ChatException;
 import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.member.exception.MemberException;
+import com.writingboard.server.domain.personal.exception.PersonalException;
 import com.writingboard.server.domain.team.exception.TeamException;
 import com.writingboard.server.domain.voice.exception.VoiceException;
 import com.writingboard.server.global.common.ErrorResponse;
@@ -61,6 +62,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TeamException.class)
     public ResponseEntity<ErrorResponse> handleTeamException(TeamException e) {
         log.warn("TeamException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(PersonalException.class)
+    public ResponseEntity<ErrorResponse> handlePersonalException(PersonalException e) {
+        log.warn("PersonalException: {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: false
     properties:
       hibernate:
@@ -23,7 +23,7 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
-    com.writingboard.server: DEBUG
+    com.writingboard.server: info
     org.springframework.messaging: DEBUG
     org.springframework.web.socket: DEBUG
     org.springframework.data.mongodb: DEBUG


### PR DESCRIPTION
### 관련 이슈 번호
#20 #15 

### 구현 상세
1. 개인 자료 관리 엔티티 및 기능 추가
  - POST /api/personal-assets - 개인 자료 생성
  - GET /api/personal-assets - 목록 조회 (페이징)
  - GET /api/personal-assets/{assetId} - 상세 조회
  - DELETE /api/personal-assets/{assetId} - 삭제

2. 회의실 자료 관리 기능 추가
  - 팀 자료/개인 자료를 회의실에 불러오기
  - 자료 활성화 (화면 표시)
  - 페이지 변경
  - 저장 정책 지원 (OVERWRITE, NEW_COPY)

  Entities:
  - RoomAsset - 회의실에 불러온 자료
  - CanvasPage - 페이지별 필기 데이터 (PencilKit binary)
  - CanvasSnapshot - 자동/수동 스냅샷

  API:
  - POST /api/rooms/{roomUuid}/assets/team - 팀 자료 불러오기
  - POST /api/rooms/{roomUuid}/assets/personal - 개인 자료 불러오기
  - GET /api/rooms/{roomUuid}/assets - 회의실 자료 목록
  - POST /api/rooms/{roomUuid}/assets/{roomAssetId}/activate - 자료 활성화
  - POST /api/rooms/{roomUuid}/assets/{roomAssetId}/page - 페이지 변경

  3. Canvas (필기 데이터) API
  - 페이지별 필기 데이터 저장/조회
  - Base64 인코딩된 바이너리 데이터 처리
  - 스냅샷 생성/복원 기능
  - 스냅샷 트리거 타입: AUTO, MANUAL, ERROR

  API:
  - GET /api/rooms/{roomUuid}/canvas/{roomAssetId}/pages/{pageIndex} - 필기 조회
  - PUT /api/rooms/{roomUuid}/canvas/{roomAssetId}/pages/{pageIndex} - 필기 저장
  - POST /api/rooms/{roomUuid}/canvas/{roomAssetId}/pages/{pageIndex}/snapshot - 스냅샷 생성
  - POST /api/rooms/{roomUuid}/canvas/{roomAssetId}/pages/{pageIndex}/restore - 스냅샷 복원

  4. Canvas Follow Feature (페이지 팔로우)
  - Redis Pub/Sub 기반 실시간 페이지 동기화
  - 참가자가 현재 보고 있는 페이지 추적
  - 특정 참가자 팔로우 기능
  - WebSocket STOMP 브로드캐스트 (/topic/room/{roomUuid}/follow)
  Components:
  - FollowRedisPublisher - Redis 채널 follow:room:{roomUuid}에 발행
  - FollowRedisSubscriber - Redis 구독 및 STOMP 브로드캐스트
  - FollowService - 현재 보는 페이지 추적, 팔로우 관리

  API:
  - POST /api/rooms/{roomUuid}/follow/viewing - 현재 페이지 업데이트
  - POST /api/rooms/{roomUuid}/follow/{targetMemberId} - 팔로우 시작
  - DELETE /api/rooms/{roomUuid}/follow - 팔로우 종료
  - GET /api/rooms/{roomUuid}/follow/participants/viewing - 참가자별 현재 페이지 조회

  5. 외부인 초대 (VIEWER)
  - 외부인 초대 시 VIEWER 권한 자동 부여
  - 팀 멤버 여부에 따른 권한 분기
  - VIEWER 권한은 읽기 전용 (자료 추가/필기 불가)