### PR TITLE
Feat: 실시간 드로잉 동기화 및 스냅샷 시스템 구현

### DIFF
--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingController.java
@@ -1,0 +1,64 @@
+package com.writingboard.server.domain.drawing.controller;
+
+import com.writingboard.server.domain.drawing.dto.request.DrawingStrokeRequest;
+import com.writingboard.server.domain.drawing.service.DrawingService;
+import com.writingboard.server.global.websocket.StompPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+/**
+ * 드로잉 WebSocket 컨트롤러
+ * Client 전송 -> /app/room/{roomUuid}/drawing
+ * Redis Pub/Sub -> /topic/room/{roomUuid}/drawing
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class DrawingController {
+
+    private final DrawingService drawingService;
+
+    /**
+     * 드로잉 스트로크 메시지 처리
+     */
+    @MessageMapping("/room/{roomUuid}/drawing")
+    public void handleDrawingStroke(
+            @DestinationVariable String roomUuid,
+            @Payload DrawingStrokeRequest request,
+            Principal principal) {
+
+        Long memberId = getMemberId(principal);
+        log.debug("드로잉 스트로크 수신: roomUuid={}, memberId={}, type={}, pageIndex={}",
+                roomUuid, memberId, request.getType(), request.getPageIndex());
+
+        drawingService.sendStroke(memberId, roomUuid, request);
+    }
+
+    /**
+     * WebSocket 메시지 처리 중 에러 핸들링
+     */
+    @MessageExceptionHandler
+    @SendToUser("/queue/errors")
+    public String handleError(Exception e) {
+        log.error("드로잉 메시지 처리 중 에러", e);
+        return e.getMessage();
+    }
+
+    /**
+     * Principal에서 memberId 추출
+     */
+    private Long getMemberId(Principal principal) {
+        if (principal instanceof StompPrincipal stompPrincipal) {
+            return stompPrincipal.getMemberId();
+        }
+        throw new IllegalStateException("인증되지 않은 사용자입니다.");
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingController.java
@@ -16,7 +16,7 @@ import java.security.Principal;
 
 /**
  * 드로잉 WebSocket 컨트롤러
- * Client 전송 -> /app/room/{roomUuid}/drawing
+ * Client 전송 -> /app/room/{roomUuid}/asset/{roomAssetId}/drawing
  * Redis Pub/Sub -> /topic/room/{roomUuid}/drawing
  */
 @Slf4j
@@ -29,15 +29,16 @@ public class DrawingController {
     /**
      * 드로잉 스트로크 메시지 처리
      */
-    @MessageMapping("/room/{roomUuid}/drawing")
+    @MessageMapping("/room/{roomUuid}/asset/{roomAssetId}/drawing")
     public void handleDrawingStroke(
             @DestinationVariable String roomUuid,
+            @DestinationVariable Long roomAssetId,
             @Payload DrawingStrokeRequest request,
             Principal principal) {
 
         Long memberId = getMemberId(principal);
-        log.debug("드로잉 스트로크 수신: roomUuid={}, memberId={}, type={}, pageIndex={}",
-                roomUuid, memberId, request.getType(), request.getPageIndex());
+        log.debug("드로잉 스트로크 수신: roomUuid={}, roomAssetId={}, memberId={}, type={}, pageIndex={}",
+                roomUuid, roomAssetId, memberId, request.getType(), request.getPageIndex());
 
         drawingService.sendStroke(memberId, roomUuid, request);
     }

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingController.java
@@ -14,11 +14,7 @@ import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
 
-/**
- * 드로잉 WebSocket 컨트롤러
- * Client 전송 -> /app/room/{roomUuid}/asset/{roomAssetId}/drawing
- * Redis Pub/Sub -> /topic/room/{roomUuid}/drawing
- */
+
 @Slf4j
 @Controller
 @RequiredArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingHistoryController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingHistoryController.java
@@ -21,16 +21,18 @@ public class DrawingHistoryController {
     private final DrawingService drawingService;
 
     /**
-     * 특정 페이지의 스트로크 히스토리 조회
+     * 특정 RoomAsset 페이지의 스트로크 히스토리 조회
      */
-    @GetMapping("/{roomUuid}/strokes")
+    @GetMapping("/{roomUuid}/assets/{roomAssetId}/strokes")
     public ResponseEntity<List<DrawingStrokeDto>> getStrokeHistory(
             @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
             @RequestParam Integer pageIndex) {
 
-        log.debug("스트로크 히스토리 조회 요청: roomUuid={}, pageIndex={}", roomUuid, pageIndex);
+        log.debug("스트로크 히스토리 조회 요청: roomUuid={}, roomAssetId={}, pageIndex={}",
+                roomUuid, roomAssetId, pageIndex);
 
-        List<DrawingStrokeDto> strokes = drawingService.getStrokeHistory(roomUuid, pageIndex);
+        List<DrawingStrokeDto> strokes = drawingService.getStrokeHistory(roomUuid, roomAssetId, pageIndex);
         return ResponseEntity.ok(strokes);
     }
 }

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingHistoryController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingHistoryController.java
@@ -9,9 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-/**
- * 드로잉 히스토리 REST API 컨트롤러
- */
+
 @Slf4j
 @RestController
 @RequestMapping("/api/rooms")

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingHistoryController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingHistoryController.java
@@ -1,0 +1,36 @@
+package com.writingboard.server.domain.drawing.controller;
+
+import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
+import com.writingboard.server.domain.drawing.service.DrawingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 드로잉 히스토리 REST API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/rooms")
+@RequiredArgsConstructor
+public class DrawingHistoryController {
+
+    private final DrawingService drawingService;
+
+    /**
+     * 특정 페이지의 스트로크 히스토리 조회
+     */
+    @GetMapping("/{roomUuid}/strokes")
+    public ResponseEntity<List<DrawingStrokeDto>> getStrokeHistory(
+            @PathVariable String roomUuid,
+            @RequestParam Integer pageIndex) {
+
+        log.debug("스트로크 히스토리 조회 요청: roomUuid={}, pageIndex={}", roomUuid, pageIndex);
+
+        List<DrawingStrokeDto> strokes = drawingService.getStrokeHistory(roomUuid, pageIndex);
+        return ResponseEntity.ok(strokes);
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
@@ -26,9 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 드로잉 스냅샷 REST API 컨트롤러
- */
+
 @Slf4j
 @RestController
 @RequestMapping("/api/rooms/{roomUuid}/assets/{roomAssetId}/snapshots")

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
@@ -1,0 +1,134 @@
+package com.writingboard.server.domain.drawing.controller;
+
+import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
+import com.writingboard.server.domain.drawing.dto.request.DrawingSnapshotRequest;
+import com.writingboard.server.domain.drawing.dto.response.DrawingSnapshotResponse;
+import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
+import com.writingboard.server.domain.drawing.enums.DrawingMessageType;
+import com.writingboard.server.domain.drawing.exception.DrawingErrorCode;
+import com.writingboard.server.domain.drawing.exception.DrawingException;
+import com.writingboard.server.domain.drawing.service.DrawingRedisPublisher;
+import com.writingboard.server.domain.drawing.service.DrawingSnapshotService;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.RoomParticipant;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 드로잉 스냅샷 REST API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/rooms/{roomUuid}/snapshots")
+@RequiredArgsConstructor
+public class DrawingSnapshotController {
+
+    private final DrawingSnapshotService snapshotService;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+    private final MemberRepository memberRepository;
+    private final DrawingRedisPublisher drawingRedisPublisher;
+
+    /**
+     * 스냅샷 생성 (HOST만 가능)
+     */
+    @PostMapping
+    public ResponseEntity<DrawingSnapshotResponse> createSnapshot(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String roomUuid,
+            @RequestBody @Valid DrawingSnapshotRequest request) {
+
+        log.debug("스냅샷 생성 요청: roomUuid={}, memberId={}, pageIndex={}, version={}",
+                roomUuid, memberId, request.getPageIndex(), request.getLastIncludedVersion());
+
+        Room room = roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.ROOM_NOT_FOUND));
+
+        if (room.getStatus() != RoomStatus.OPEN) {
+            throw new DrawingException(DrawingErrorCode.ROOM_CLOSED);
+        }
+
+        RoomParticipant participant = participantRepository
+                .findByRoomIdAndMemberId(room.getId(), memberId)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.NOT_PARTICIPANT));
+
+        if (participant.getState() != ParticipantState.JOINED) {
+            throw new DrawingException(DrawingErrorCode.NOT_PARTICIPANT);
+        }
+
+        if (participant.getRole() != ParticipantRole.HOST) {
+            throw new DrawingException(DrawingErrorCode.SNAPSHOT_PERMISSION_DENIED);
+        }
+
+        DrawingSnapshot snapshot = snapshotService.saveSnapshot(
+                memberId,
+                roomUuid,
+                request.getPageIndex(),
+                request.getLastIncludedVersion(),
+                request.getSnapshotData()
+        );
+
+        broadcastSnapshotNotification(snapshot);
+
+        DrawingSnapshotResponse response = DrawingSnapshotResponse.from(snapshot);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 특정 페이지의 최신 스냅샷 조회
+     */
+    @GetMapping("/latest")
+    public ResponseEntity<DrawingSnapshotResponse> getLatestSnapshot(
+            @PathVariable String roomUuid,
+            @RequestParam Integer pageIndex) {
+
+        log.debug("최신 스냅샷 조회 요청: roomUuid={}, pageIndex={}", roomUuid, pageIndex);
+
+        DrawingSnapshot snapshot = snapshotService.getLatestSnapshot(roomUuid, pageIndex)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.SNAPSHOT_NOT_FOUND));
+
+        return ResponseEntity.ok(DrawingSnapshotResponse.from(snapshot));
+    }
+
+    /**
+     * 스냅샷 생성 알림 브로드캐스트
+     */
+    private void broadcastSnapshotNotification(DrawingSnapshot snapshot) {
+        try {
+            Member creator = memberRepository.findById(snapshot.getCreatedBy())
+                    .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
+
+            DrawingStrokeDto notificationDto = DrawingStrokeDto.of(
+                    snapshot.getRoomUuid(),
+                    creator.getId(),
+                    creator.getName(),
+                    DrawingMessageType.SNAPSHOT,
+                    snapshot.getPageIndex(),
+                    null,
+                    null,
+                    snapshot.getVersion()
+            );
+
+            drawingRedisPublisher.publish(snapshot.getRoomUuid(), notificationDto);
+
+            log.debug("스냅샷 생성 알림 브로드캐스트: roomUuid={}, version={}",
+                    snapshot.getRoomUuid(), snapshot.getVersion());
+
+        } catch (Exception e) {
+            log.error("스냅샷 알림 브로드캐스트 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @Slf4j
 @RestController
-@RequestMapping("/api/rooms/{roomUuid}/snapshots")
+@RequestMapping("/api/rooms/{roomUuid}/assets/{roomAssetId}/snapshots")
 @RequiredArgsConstructor
 public class DrawingSnapshotController {
 
@@ -48,10 +48,11 @@ public class DrawingSnapshotController {
     public ResponseEntity<DrawingSnapshotResponse> createSnapshot(
             @AuthenticationPrincipal Long memberId,
             @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
             @RequestBody @Valid DrawingSnapshotRequest request) {
 
-        log.debug("스냅샷 생성 요청: roomUuid={}, memberId={}, pageIndex={}, version={}",
-                roomUuid, memberId, request.getPageIndex(), request.getLastIncludedVersion());
+        log.debug("스냅샷 생성 요청: roomUuid={}, roomAssetId={}, memberId={}, pageIndex={}, version={}",
+                roomUuid, roomAssetId, memberId, request.getPageIndex(), request.getLastIncludedVersion());
 
         Room room = roomRepository.findByRoomUuid(roomUuid)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.ROOM_NOT_FOUND));
@@ -75,6 +76,7 @@ public class DrawingSnapshotController {
         DrawingSnapshot snapshot = snapshotService.saveSnapshot(
                 memberId,
                 roomUuid,
+                roomAssetId,
                 request.getPageIndex(),
                 request.getLastIncludedVersion(),
                 request.getSnapshotData()
@@ -88,16 +90,18 @@ public class DrawingSnapshotController {
     }
 
     /**
-     * 특정 페이지의 최신 스냅샷 조회
+     * 특정 RoomAsset 페이지의 최신 스냅샷 조회
      */
     @GetMapping("/latest")
     public ResponseEntity<DrawingSnapshotResponse> getLatestSnapshot(
             @PathVariable String roomUuid,
+            @PathVariable Long roomAssetId,
             @RequestParam Integer pageIndex) {
 
-        log.debug("최신 스냅샷 조회 요청: roomUuid={}, pageIndex={}", roomUuid, pageIndex);
+        log.debug("최신 스냅샷 조회 요청: roomUuid={}, roomAssetId={}, pageIndex={}",
+                roomUuid, roomAssetId, pageIndex);
 
-        DrawingSnapshot snapshot = snapshotService.getLatestSnapshot(roomUuid, pageIndex)
+        DrawingSnapshot snapshot = snapshotService.getLatestSnapshot(roomAssetId, pageIndex)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.SNAPSHOT_NOT_FOUND));
 
         return ResponseEntity.ok(DrawingSnapshotResponse.from(snapshot));
@@ -113,6 +117,7 @@ public class DrawingSnapshotController {
 
             DrawingStrokeDto notificationDto = DrawingStrokeDto.of(
                     snapshot.getRoomUuid(),
+                    snapshot.getRoomAssetId(),
                     creator.getId(),
                     creator.getName(),
                     DrawingMessageType.SNAPSHOT,
@@ -124,8 +129,8 @@ public class DrawingSnapshotController {
 
             drawingRedisPublisher.publish(snapshot.getRoomUuid(), notificationDto);
 
-            log.debug("스냅샷 생성 알림 브로드캐스트: roomUuid={}, version={}",
-                    snapshot.getRoomUuid(), snapshot.getVersion());
+            log.debug("스냅샷 생성 알림 브로드캐스트: roomUuid={}, roomAssetId={}, version={}",
+                    snapshot.getRoomUuid(), snapshot.getRoomAssetId(), snapshot.getVersion());
 
         } catch (Exception e) {
             log.error("스냅샷 알림 브로드캐스트 실패", e);

--- a/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
@@ -1,0 +1,60 @@
+package com.writingboard.server.domain.drawing.document;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+/**
+ * 드로잉 스냅샷 MongoDB 문서
+ * 페이지별 PKDrawing 병합 데이터 저장
+ */
+@Document(collection = "drawing_snapshots")
+@CompoundIndex(name = "idx_room_page_version", def = "{'roomUuid': 1, 'pageIndex': 1, 'version': -1}")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DrawingSnapshot {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String roomUuid;
+
+    @Indexed
+    private Integer pageIndex;
+
+    private Long version;
+
+    private String snapshotData;
+
+    private Long createdBy;
+    private String createdByName;
+
+    @Indexed
+    private Instant createdAt;
+
+    private DrawingSnapshot(String roomUuid, Integer pageIndex, Long version,
+                           String snapshotData, Long createdBy, String createdByName) {
+        this.roomUuid = roomUuid;
+        this.pageIndex = pageIndex;
+        this.version = version;
+        this.snapshotData = snapshotData;
+        this.createdBy = createdBy;
+        this.createdByName = createdByName;
+        this.createdAt = Instant.now();
+    }
+
+    /**
+     * 드로잉 스냅샷 생성 팩토리 메서드
+     */
+    public static DrawingSnapshot create(String roomUuid, Integer pageIndex, Long version,
+                                        String snapshotData, Long createdBy, String createdByName) {
+        return new DrawingSnapshot(roomUuid, pageIndex, version, snapshotData, createdBy, createdByName);
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
@@ -10,10 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
 
-/**
- * 드로잉 스냅샷 MongoDB 문서
- * RoomAsset의 페이지별 PKDrawing 병합 데이터 저장
- */
+
 @Document(collection = "drawing_snapshots")
 @CompoundIndex(name = "idx_asset_page_version", def = "{'roomAssetId': 1, 'pageIndex': 1, 'version': -1}")
 @CompoundIndex(name = "idx_room_page_version", def = "{'roomUuid': 1, 'pageIndex': 1, 'version': -1}")
@@ -55,9 +52,6 @@ public class DrawingSnapshot {
         this.createdAt = Instant.now();
     }
 
-    /**
-     * 드로잉 스냅샷 생성 팩토리 메서드
-     */
     public static DrawingSnapshot create(String roomUuid, Long roomAssetId, Integer pageIndex, Long version,
                                         String snapshotData, Long createdBy, String createdByName) {
         return new DrawingSnapshot(roomUuid, roomAssetId, pageIndex, version, snapshotData, createdBy, createdByName);

--- a/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
@@ -50,9 +50,6 @@ public class DrawingSnapshot {
         this.createdAt = Instant.now();
     }
 
-    /**
-     * 드로잉 스냅샷 생성 팩토리 메서드
-     */
     public static DrawingSnapshot create(String roomUuid, Integer pageIndex, Long version,
                                         String snapshotData, Long createdBy, String createdByName) {
         return new DrawingSnapshot(roomUuid, pageIndex, version, snapshotData, createdBy, createdByName);

--- a/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
@@ -12,9 +12,10 @@ import java.time.Instant;
 
 /**
  * 드로잉 스냅샷 MongoDB 문서
- * 페이지별 PKDrawing 병합 데이터 저장
+ * RoomAsset의 페이지별 PKDrawing 병합 데이터 저장
  */
 @Document(collection = "drawing_snapshots")
+@CompoundIndex(name = "idx_asset_page_version", def = "{'roomAssetId': 1, 'pageIndex': 1, 'version': -1}")
 @CompoundIndex(name = "idx_room_page_version", def = "{'roomUuid': 1, 'pageIndex': 1, 'version': -1}")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,6 +26,9 @@ public class DrawingSnapshot {
 
     @Indexed
     private String roomUuid;
+
+    @Indexed
+    private Long roomAssetId;
 
     @Indexed
     private Integer pageIndex;
@@ -39,9 +43,10 @@ public class DrawingSnapshot {
     @Indexed
     private Instant createdAt;
 
-    private DrawingSnapshot(String roomUuid, Integer pageIndex, Long version,
+    private DrawingSnapshot(String roomUuid, Long roomAssetId, Integer pageIndex, Long version,
                            String snapshotData, Long createdBy, String createdByName) {
         this.roomUuid = roomUuid;
+        this.roomAssetId = roomAssetId;
         this.pageIndex = pageIndex;
         this.version = version;
         this.snapshotData = snapshotData;
@@ -50,8 +55,11 @@ public class DrawingSnapshot {
         this.createdAt = Instant.now();
     }
 
-    public static DrawingSnapshot create(String roomUuid, Integer pageIndex, Long version,
+    /**
+     * 드로잉 스냅샷 생성 팩토리 메서드
+     */
+    public static DrawingSnapshot create(String roomUuid, Long roomAssetId, Integer pageIndex, Long version,
                                         String snapshotData, Long createdBy, String createdByName) {
-        return new DrawingSnapshot(roomUuid, pageIndex, version, snapshotData, createdBy, createdByName);
+        return new DrawingSnapshot(roomUuid, roomAssetId, pageIndex, version, snapshotData, createdBy, createdByName);
     }
 }

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingSnapshotRequest.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingSnapshotRequest.java
@@ -5,9 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 드로잉 스냅샷 생성 요청 DTO
- */
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingSnapshotRequest.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingSnapshotRequest.java
@@ -1,0 +1,28 @@
+package com.writingboard.server.domain.drawing.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 드로잉 스냅샷 생성 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrawingSnapshotRequest {
+
+    @NotNull(message = "페이지 인덱스는 필수입니다")
+    @Min(value = 0, message = "페이지 인덱스는 0 이상이어야 합니다")
+    @Max(value = 999, message = "페이지 인덱스는 999 이하여야 합니다")
+    private Integer pageIndex;
+
+    @NotNull(message = "마지막 포함 버전은 필수입니다")
+    @Min(value = 1, message = "버전은 1 이상이어야 합니다")
+    private Long lastIncludedVersion;
+
+    @NotBlank(message = "스냅샷 데이터는 필수입니다")
+    @Size(max = 500000, message = "스냅샷 데이터는 최대 500000자까지 가능합니다")
+    private String snapshotData;
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
@@ -1,0 +1,35 @@
+package com.writingboard.server.domain.drawing.dto.request;
+
+import com.writingboard.server.domain.drawing.enums.DrawingMessageType;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 드로잉 스트로크 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrawingStrokeRequest {
+
+    @NotNull(message = "메시지 타입은 필수입니다")
+    private DrawingMessageType type;
+
+    @NotNull(message = "페이지 인덱스는 필수입니다")
+    @Min(value = 0, message = "페이지 인덱스는 0 이상이어야 합니다")
+    @Max(value = 999, message = "페이지 인덱스는 999 이하여야 합니다")
+    private Integer pageIndex;
+
+    @Size(max = 100, message = "스트로크 ID는 최대 100자까지 가능합니다")
+    private String strokeId;
+
+    @Size(max = 100000, message = "스트로크 데이터는 최대 100000자까지 가능합니다")
+    private String strokeData;
+
+    private Long version;
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
@@ -10,6 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
+/**
+ * 드로잉 스트로크 요청 DTO (WebSocket 전용)
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -17,6 +20,9 @@ public class DrawingStrokeRequest {
 
     @NotNull(message = "메시지 타입은 필수입니다")
     private DrawingMessageType type;
+
+    @NotNull(message = "RoomAsset ID는 필수입니다")
+    private Long roomAssetId;
 
     @NotNull(message = "페이지 인덱스는 필수입니다")
     @Min(value = 0, message = "페이지 인덱스는 0 이상이어야 합니다")

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
@@ -9,9 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 드로잉 스트로크 요청 DTO
- */
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/request/DrawingStrokeRequest.java
@@ -10,9 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
-/**
- * 드로잉 스트로크 요청 DTO (WebSocket 전용)
- */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
@@ -1,0 +1,55 @@
+package com.writingboard.server.domain.drawing.dto.response;
+
+import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * 드로잉 스냅샷 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class DrawingSnapshotResponse {
+
+    private String id;
+    private String roomUuid;
+    private Integer pageIndex;
+    private Long version;
+    private String snapshotData;
+    private Long createdBy;
+    private String createdByName;
+    private Instant createdAt;
+
+    @Builder
+    public DrawingSnapshotResponse(String id, String roomUuid, Integer pageIndex,
+                                  Long version, String snapshotData,
+                                  Long createdBy, String createdByName, Instant createdAt) {
+        this.id = id;
+        this.roomUuid = roomUuid;
+        this.pageIndex = pageIndex;
+        this.version = version;
+        this.snapshotData = snapshotData;
+        this.createdBy = createdBy;
+        this.createdByName = createdByName;
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * DrawingSnapshot 문서를 DTO로 변환
+     */
+    public static DrawingSnapshotResponse from(DrawingSnapshot snapshot) {
+        return DrawingSnapshotResponse.builder()
+                .id(snapshot.getId())
+                .roomUuid(snapshot.getRoomUuid())
+                .pageIndex(snapshot.getPageIndex())
+                .version(snapshot.getVersion())
+                .snapshotData(snapshot.getSnapshotData())
+                .createdBy(snapshot.getCreatedBy())
+                .createdByName(snapshot.getCreatedByName())
+                .createdAt(snapshot.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
@@ -7,9 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
-/**
- * 드로잉 스냅샷 응답 DTO
- */
+
 @Getter
 @NoArgsConstructor
 public class DrawingSnapshotResponse {
@@ -37,9 +35,7 @@ public class DrawingSnapshotResponse {
         this.createdAt = createdAt;
     }
 
-    /**
-     * DrawingSnapshot 문서를 DTO로 변환
-     */
+
     public static DrawingSnapshotResponse from(DrawingSnapshot snapshot) {
         return DrawingSnapshotResponse.builder()
                 .id(snapshot.getId())

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
@@ -8,9 +8,6 @@ import lombok.NoArgsConstructor;
 import java.time.Instant;
 
 
-/**
- * 드로잉 스냅샷 응답 DTO
- */
 @Getter
 @NoArgsConstructor
 public class DrawingSnapshotResponse {
@@ -40,9 +37,6 @@ public class DrawingSnapshotResponse {
         this.createdAt = createdAt;
     }
 
-    /**
-     * DrawingSnapshot 문서를 DTO로 변환
-     */
     public static DrawingSnapshotResponse from(DrawingSnapshot snapshot) {
         return DrawingSnapshotResponse.builder()
                 .id(snapshot.getId())

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingSnapshotResponse.java
@@ -8,12 +8,16 @@ import lombok.NoArgsConstructor;
 import java.time.Instant;
 
 
+/**
+ * 드로잉 스냅샷 응답 DTO
+ */
 @Getter
 @NoArgsConstructor
 public class DrawingSnapshotResponse {
 
     private String id;
     private String roomUuid;
+    private Long roomAssetId;
     private Integer pageIndex;
     private Long version;
     private String snapshotData;
@@ -22,11 +26,12 @@ public class DrawingSnapshotResponse {
     private Instant createdAt;
 
     @Builder
-    public DrawingSnapshotResponse(String id, String roomUuid, Integer pageIndex,
+    public DrawingSnapshotResponse(String id, String roomUuid, Long roomAssetId, Integer pageIndex,
                                   Long version, String snapshotData,
                                   Long createdBy, String createdByName, Instant createdAt) {
         this.id = id;
         this.roomUuid = roomUuid;
+        this.roomAssetId = roomAssetId;
         this.pageIndex = pageIndex;
         this.version = version;
         this.snapshotData = snapshotData;
@@ -35,11 +40,14 @@ public class DrawingSnapshotResponse {
         this.createdAt = createdAt;
     }
 
-
+    /**
+     * DrawingSnapshot 문서를 DTO로 변환
+     */
     public static DrawingSnapshotResponse from(DrawingSnapshot snapshot) {
         return DrawingSnapshotResponse.builder()
                 .id(snapshot.getId())
                 .roomUuid(snapshot.getRoomUuid())
+                .roomAssetId(snapshot.getRoomAssetId())
                 .pageIndex(snapshot.getPageIndex())
                 .version(snapshot.getVersion())
                 .snapshotData(snapshot.getSnapshotData())

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
@@ -8,9 +8,7 @@ import lombok.NoArgsConstructor;
 import java.time.Instant;
 
 
-/**
- * 드로잉 스트로크 응답 DTO
- */
+
 @Getter
 @NoArgsConstructor
 public class DrawingStrokeDto {
@@ -43,9 +41,7 @@ public class DrawingStrokeDto {
         this.timestamp = timestamp;
     }
 
-    /**
-     * DrawingStrokeDto 생성 팩토리 메서드
-     */
+
     public static DrawingStrokeDto of(String roomUuid, Long roomAssetId, Long senderId, String senderName,
                                       DrawingMessageType type, Integer pageIndex,
                                       String strokeId, String strokeData, Long version) {

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
@@ -1,0 +1,61 @@
+package com.writingboard.server.domain.drawing.dto.response;
+
+import com.writingboard.server.domain.drawing.enums.DrawingMessageType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * 드로잉 스트로크 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class DrawingStrokeDto {
+
+    private String roomUuid;
+    private Long senderId;
+    private String senderName;
+    private DrawingMessageType type;
+    private Integer pageIndex;
+    private String strokeId;
+    private String strokeData;
+    private Long version;
+    private Instant timestamp;
+
+    @Builder
+    public DrawingStrokeDto(String roomUuid, Long senderId, String senderName,
+                            DrawingMessageType type, Integer pageIndex,
+                            String strokeId, String strokeData, Long version,
+                            Instant timestamp) {
+        this.roomUuid = roomUuid;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.type = type;
+        this.pageIndex = pageIndex;
+        this.strokeId = strokeId;
+        this.strokeData = strokeData;
+        this.version = version;
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * DrawingStrokeDto 생성 팩토리 메서드
+     */
+    public static DrawingStrokeDto of(String roomUuid, Long senderId, String senderName,
+                                      DrawingMessageType type, Integer pageIndex,
+                                      String strokeId, String strokeData, Long version) {
+        return DrawingStrokeDto.builder()
+                .roomUuid(roomUuid)
+                .senderId(senderId)
+                .senderName(senderName)
+                .type(type)
+                .pageIndex(pageIndex)
+                .strokeId(strokeId)
+                .strokeData(strokeData)
+                .version(version)
+                .timestamp(Instant.now())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
@@ -8,11 +8,15 @@ import lombok.NoArgsConstructor;
 import java.time.Instant;
 
 
+/**
+ * 드로잉 스트로크 응답 DTO
+ */
 @Getter
 @NoArgsConstructor
 public class DrawingStrokeDto {
 
     private String roomUuid;
+    private Long roomAssetId;
     private Long senderId;
     private String senderName;
     private DrawingMessageType type;
@@ -23,11 +27,12 @@ public class DrawingStrokeDto {
     private Instant timestamp;
 
     @Builder
-    public DrawingStrokeDto(String roomUuid, Long senderId, String senderName,
+    public DrawingStrokeDto(String roomUuid, Long roomAssetId, Long senderId, String senderName,
                             DrawingMessageType type, Integer pageIndex,
                             String strokeId, String strokeData, Long version,
                             Instant timestamp) {
         this.roomUuid = roomUuid;
+        this.roomAssetId = roomAssetId;
         this.senderId = senderId;
         this.senderName = senderName;
         this.type = type;
@@ -41,11 +46,12 @@ public class DrawingStrokeDto {
     /**
      * DrawingStrokeDto 생성 팩토리 메서드
      */
-    public static DrawingStrokeDto of(String roomUuid, Long senderId, String senderName,
+    public static DrawingStrokeDto of(String roomUuid, Long roomAssetId, Long senderId, String senderName,
                                       DrawingMessageType type, Integer pageIndex,
                                       String strokeId, String strokeData, Long version) {
         return DrawingStrokeDto.builder()
                 .roomUuid(roomUuid)
+                .roomAssetId(roomAssetId)
                 .senderId(senderId)
                 .senderName(senderName)
                 .type(type)

--- a/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/dto/response/DrawingStrokeDto.java
@@ -7,9 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
-/**
- * 드로잉 스트로크 응답 DTO
- */
+
 @Getter
 @NoArgsConstructor
 public class DrawingStrokeDto {

--- a/src/main/java/com/writingboard/server/domain/drawing/enums/DrawingMessageType.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/enums/DrawingMessageType.java
@@ -1,0 +1,13 @@
+package com.writingboard.server.domain.drawing.enums;
+
+/**
+ * 드로잉 메시지 타입
+ * - ADD: 새로운 스트로크 추가
+ * - REMOVE: 기존 스트로크 제거
+ * - SNAPSHOT: 전체 드로잉 스냅샷
+ */
+public enum DrawingMessageType {
+    ADD,
+    REMOVE,
+    SNAPSHOT
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
@@ -35,7 +35,10 @@ public enum DrawingErrorCode {
     // Snapshot
     SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAWING_012", "스냅샷을 찾을 수 없습니다"),
     SNAPSHOT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DRAWING_013", "스냅샷 저장에 실패했습니다"),
-    SNAPSHOT_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "DRAWING_014", "스냅샷 생성 권한이 없습니다 (HOST만 가능)");
+    SNAPSHOT_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "DRAWING_014", "스냅샷 생성 권한이 없습니다 (HOST만 가능)"),
+
+    // RoomAsset
+    ROOM_ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAWING_015", "RoomAsset을 찾을 수 없거나 해당 방에 속하지 않습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
@@ -4,9 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-/**
- * 드로잉 도메인 에러 코드
- */
+
 @Getter
 @RequiredArgsConstructor
 public enum DrawingErrorCode {

--- a/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
@@ -30,7 +30,12 @@ public enum DrawingErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAWING_010", "사용자를 찾을 수 없습니다"),
 
     // Redis
-    REDIS_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DRAWING_011", "Redis 작업 중 오류가 발생했습니다");
+    REDIS_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DRAWING_011", "Redis 작업 중 오류가 발생했습니다"),
+
+    // Snapshot
+    SNAPSHOT_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAWING_012", "스냅샷을 찾을 수 없습니다"),
+    SNAPSHOT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DRAWING_013", "스냅샷 저장에 실패했습니다"),
+    SNAPSHOT_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "DRAWING_014", "스냅샷 생성 권한이 없습니다 (HOST만 가능)");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
@@ -1,0 +1,38 @@
+package com.writingboard.server.domain.drawing.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 드로잉 도메인 에러 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum DrawingErrorCode {
+
+    // Stroke Data Validation
+    INVALID_STROKE_DATA(HttpStatus.BAD_REQUEST, "DRAWING_001", "유효하지 않은 스트로크 데이터입니다"),
+    STROKE_DATA_TOO_LARGE(HttpStatus.BAD_REQUEST, "DRAWING_002", "스트로크 데이터가 너무 큽니다 (최대 100000자)"),
+    STROKE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_003", "ADD 또는 REMOVE 타입은 strokeId가 필수입니다"),
+    STROKE_DATA_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_004", "ADD 또는 SNAPSHOT 타입은 strokeData가 필수입니다"),
+    VERSION_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_005", "SNAPSHOT 타입은 version이 필수입니다"),
+    INVALID_PAGE_INDEX(HttpStatus.BAD_REQUEST, "DRAWING_006", "유효하지 않은 페이지 인덱스입니다"),
+
+    // Room
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAWING_007", "회의실을 찾을 수 없습니다"),
+    ROOM_CLOSED(HttpStatus.BAD_REQUEST, "DRAWING_008", "종료된 회의실에서는 드로잉을 사용할 수 없습니다"),
+
+    // Participant
+    NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "DRAWING_009", "해당 회의실의 참여자가 아닙니다"),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "DRAWING_010", "사용자를 찾을 수 없습니다"),
+
+    // Redis
+    REDIS_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "DRAWING_011", "Redis 작업 중 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingErrorCode.java
@@ -11,12 +11,14 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum DrawingErrorCode {
 
+    // Message Type Validation
+    INVALID_MESSAGE_TYPE(HttpStatus.BAD_REQUEST, "DRAWING_001", "WebSocket으로는 ADD, REMOVE만 가능합니다 (SNAPSHOT은 REST API 사용)"),
+
     // Stroke Data Validation
-    INVALID_STROKE_DATA(HttpStatus.BAD_REQUEST, "DRAWING_001", "유효하지 않은 스트로크 데이터입니다"),
-    STROKE_DATA_TOO_LARGE(HttpStatus.BAD_REQUEST, "DRAWING_002", "스트로크 데이터가 너무 큽니다 (최대 100000자)"),
-    STROKE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_003", "ADD 또는 REMOVE 타입은 strokeId가 필수입니다"),
-    STROKE_DATA_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_004", "ADD 또는 SNAPSHOT 타입은 strokeData가 필수입니다"),
-    VERSION_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_005", "SNAPSHOT 타입은 version이 필수입니다"),
+    INVALID_STROKE_DATA(HttpStatus.BAD_REQUEST, "DRAWING_002", "유효하지 않은 스트로크 데이터입니다"),
+    STROKE_DATA_TOO_LARGE(HttpStatus.BAD_REQUEST, "DRAWING_003", "스트로크 데이터가 너무 큽니다 (최대 100000자)"),
+    STROKE_ID_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_004", "ADD 또는 REMOVE 타입은 strokeId가 필수입니다"),
+    STROKE_DATA_REQUIRED(HttpStatus.BAD_REQUEST, "DRAWING_005", "ADD 타입은 strokeData가 필수입니다"),
     INVALID_PAGE_INDEX(HttpStatus.BAD_REQUEST, "DRAWING_006", "유효하지 않은 페이지 인덱스입니다"),
 
     // Room

--- a/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingException.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingException.java
@@ -2,9 +2,7 @@ package com.writingboard.server.domain.drawing.exception;
 
 import lombok.Getter;
 
-/**
- * 드로잉 도메인 커스텀 예외
- */
+
 @Getter
 public class DrawingException extends RuntimeException {
 

--- a/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingException.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/exception/DrawingException.java
@@ -1,0 +1,22 @@
+package com.writingboard.server.domain.drawing.exception;
+
+import lombok.Getter;
+
+/**
+ * 드로잉 도메인 커스텀 예외
+ */
+@Getter
+public class DrawingException extends RuntimeException {
+
+    private final DrawingErrorCode errorCode;
+
+    public DrawingException(DrawingErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public DrawingException(DrawingErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
@@ -8,35 +8,24 @@ import java.util.Optional;
 
 public interface DrawingSnapshotRepository extends MongoRepository<DrawingSnapshot, String> {
 
-    /**
-     * 특정 RoomAsset 페이지의 최신 스냅샷 조회 (Primary - roomAssetId 기준)
-     */
     Optional<DrawingSnapshot> findFirstByRoomAssetIdAndPageIndexOrderByVersionDesc(
             Long roomAssetId,
             Integer pageIndex
     );
 
-    /**
-     * 특정 RoomAsset 페이지의 특정 버전 스냅샷 조회
-     */
     Optional<DrawingSnapshot> findByRoomAssetIdAndPageIndexAndVersion(
             Long roomAssetId,
             Integer pageIndex,
             Long version
     );
 
-    /**
-     * 특정 캔버스 페이지의 최신 스냅샷 조회 (Deprecated - backward compatibility)
-     */
+
     @Deprecated
     Optional<DrawingSnapshot> findFirstByRoomUuidAndPageIndexOrderByVersionDesc(
             String roomUuid,
             Integer pageIndex
     );
 
-    /**
-     * 특정 버전의 스냅샷 조회 (Deprecated - backward compatibility)
-     */
     @Deprecated
     Optional<DrawingSnapshot> findByRoomUuidAndPageIndexAndVersion(
             String roomUuid,

--- a/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
@@ -8,17 +8,12 @@ import java.util.Optional;
 
 public interface DrawingSnapshotRepository extends MongoRepository<DrawingSnapshot, String> {
 
-    /**
-     * 특정 캔버스 페이지의 최신 스냅샷 조회 (version DESC 정렬)
-     */
+
     Optional<DrawingSnapshot> findFirstByRoomUuidAndPageIndexOrderByVersionDesc(
             String roomUuid,
             Integer pageIndex
     );
 
-    /**
-     * 특정 버전의 스냅샷 조회
-     */
     Optional<DrawingSnapshot> findByRoomUuidAndPageIndexAndVersion(
             String roomUuid,
             Integer pageIndex,

--- a/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
@@ -1,25 +1,19 @@
 package com.writingboard.server.domain.drawing.repository;
 
 import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 
 import java.util.Optional;
 
-/**
- * 드로잉 스냅샷 MongoDB 레포지토리
- */
+
 public interface DrawingSnapshotRepository extends MongoRepository<DrawingSnapshot, String> {
 
     /**
-     * 특정 페이지의 최신 스냅샷 조회
+     * 특정 캔버스 페이지의 최신 스냅샷 조회 (version DESC 정렬)
      */
-    @Query("{ 'roomUuid': ?0, 'pageIndex': ?1 }")
-    Optional<DrawingSnapshot> findLatestByRoomUuidAndPageIndex(
+    Optional<DrawingSnapshot> findFirstByRoomUuidAndPageIndexOrderByVersionDesc(
             String roomUuid,
-            Integer pageIndex,
-            Pageable pageable
+            Integer pageIndex
     );
 
     /**

--- a/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
@@ -1,0 +1,33 @@
+package com.writingboard.server.domain.drawing.repository;
+
+import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.Optional;
+
+/**
+ * 드로잉 스냅샷 MongoDB 레포지토리
+ */
+public interface DrawingSnapshotRepository extends MongoRepository<DrawingSnapshot, String> {
+
+    /**
+     * 특정 페이지의 최신 스냅샷 조회
+     */
+    @Query("{ 'roomUuid': ?0, 'pageIndex': ?1 }")
+    Optional<DrawingSnapshot> findLatestByRoomUuidAndPageIndex(
+            String roomUuid,
+            Integer pageIndex,
+            Pageable pageable
+    );
+
+    /**
+     * 특정 버전의 스냅샷 조회
+     */
+    Optional<DrawingSnapshot> findByRoomUuidAndPageIndexAndVersion(
+            String roomUuid,
+            Integer pageIndex,
+            Long version
+    );
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
@@ -8,12 +8,36 @@ import java.util.Optional;
 
 public interface DrawingSnapshotRepository extends MongoRepository<DrawingSnapshot, String> {
 
+    /**
+     * 특정 RoomAsset 페이지의 최신 스냅샷 조회 (Primary - roomAssetId 기준)
+     */
+    Optional<DrawingSnapshot> findFirstByRoomAssetIdAndPageIndexOrderByVersionDesc(
+            Long roomAssetId,
+            Integer pageIndex
+    );
 
+    /**
+     * 특정 RoomAsset 페이지의 특정 버전 스냅샷 조회
+     */
+    Optional<DrawingSnapshot> findByRoomAssetIdAndPageIndexAndVersion(
+            Long roomAssetId,
+            Integer pageIndex,
+            Long version
+    );
+
+    /**
+     * 특정 캔버스 페이지의 최신 스냅샷 조회 (Deprecated - backward compatibility)
+     */
+    @Deprecated
     Optional<DrawingSnapshot> findFirstByRoomUuidAndPageIndexOrderByVersionDesc(
             String roomUuid,
             Integer pageIndex
     );
 
+    /**
+     * 특정 버전의 스냅샷 조회 (Deprecated - backward compatibility)
+     */
+    @Deprecated
     Optional<DrawingSnapshot> findByRoomUuidAndPageIndexAndVersion(
             String roomUuid,
             Integer pageIndex,

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisPublisher.java
@@ -6,9 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-/**
- * 드로잉 Redis 메시지 발행 서비스
- */
+
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisPublisher.java
@@ -1,0 +1,35 @@
+package com.writingboard.server.domain.drawing.service;
+
+import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 드로잉 Redis 메시지 발행 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrawingRedisPublisher {
+
+    private static final String CHANNEL_PREFIX = "drawing:room:";
+
+    private final RedisTemplate<String, DrawingStrokeDto> drawingRedisTemplate;
+
+    /**
+     * 드로잉 스트로크 메시지를 Redis 채널에 발행
+     */
+    public void publish(String roomUuid, DrawingStrokeDto strokeDto) {
+        String channel = CHANNEL_PREFIX + roomUuid;
+
+        try {
+            drawingRedisTemplate.convertAndSend(channel, strokeDto);
+            log.debug("Redis 드로잉 메시지 발행: channel={}, type={}, pageIndex={}",
+                    channel, strokeDto.getType(), strokeDto.getPageIndex());
+        } catch (Exception e) {
+            log.error("Redis 드로잉 메시지 발행 실패: channel={}", channel, e);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisSubscriber.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisSubscriber.java
@@ -1,0 +1,56 @@
+package com.writingboard.server.domain.drawing.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * 드로잉 Redis 메시지 구독 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DrawingRedisSubscriber implements MessageListener {
+
+    private static final String CHANNEL_PREFIX = "drawing:room:";
+    private static final String TOPIC_PREFIX = "/topic/room/";
+    private static final String DRAWING_SUFFIX = "/drawing";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Redis에서 메시지를 수신하여 WebSocket으로 브로드캐스트
+     */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String body = new String(message.getBody());
+
+            DrawingStrokeDto strokeDto = objectMapper.readValue(body, DrawingStrokeDto.class);
+            String roomUuid = extractRoomUuid(channel);
+
+            String destination = TOPIC_PREFIX + roomUuid + DRAWING_SUFFIX;
+            messagingTemplate.convertAndSend(destination, strokeDto);
+
+            log.debug("클라이언트로 드로잉 메시지 전송: destination={}, type={}, pageIndex={}",
+                    destination, strokeDto.getType(), strokeDto.getPageIndex());
+
+        } catch (Exception e) {
+            log.error("Redis 드로잉 메시지 처리 실패", e);
+        }
+    }
+
+    /**
+     * Redis 채널명에서 roomUuid 추출
+     */
+    private String extractRoomUuid(String channel) {
+        return channel.replace(CHANNEL_PREFIX, "");
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisSubscriber.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingRedisSubscriber.java
@@ -9,9 +9,7 @@ import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
-/**
- * 드로잉 Redis 메시지 구독 서비스
- */
+
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -22,9 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-/**
- * 드로잉 비즈니스 로직 서비스
- */
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -55,7 +53,6 @@ public class DrawingService {
             throw new DrawingException(DrawingErrorCode.ROOM_CLOSED);
         }
 
-        // RoomAsset 검증 (roomAssetId가 해당 room에 속하는지 확인)
         RoomAsset roomAsset = validateRoomAsset(room.getId(), request.getRoomAssetId());
 
         validateParticipant(room.getId(), memberId);
@@ -63,7 +60,6 @@ public class DrawingService {
         Member sender = memberRepository.findById(memberId)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
 
-        // 서버에서 버전 할당 (Redis INCR)
         Long version = assignVersion(roomUuid, request.getRoomAssetId(), request.getPageIndex());
 
         DrawingStrokeDto strokeDto = DrawingStrokeDto.of(
@@ -78,10 +74,9 @@ public class DrawingService {
                 version
         );
 
-        // Redis List에 버퍼링 (asset + 페이지별 분리)
+
         bufferStroke(roomUuid, request.getRoomAssetId(), request.getPageIndex(), strokeDto);
 
-        // Redis Pub/Sub로 실시간 브로드캐스트
         drawingRedisPublisher.publish(roomUuid, strokeDto);
 
         log.debug("드로잉 스트로크 전송 완료: roomUuid={}, roomAssetId={}, senderId={}, type={}, pageIndex={}",
@@ -120,24 +115,20 @@ public class DrawingService {
     private void validateStrokeRequest(DrawingStrokeRequest request) {
         DrawingMessageType type = request.getType();
 
-        // SNAPSHOT 타입은 WebSocket으로 받지 않음 (REST API 전용)
         if (type == DrawingMessageType.SNAPSHOT) {
             throw new DrawingException(DrawingErrorCode.INVALID_MESSAGE_TYPE);
         }
 
-        // ADD, REMOVE 타입은 strokeId 필수
         if ((type == DrawingMessageType.ADD || type == DrawingMessageType.REMOVE)
                 && (request.getStrokeId() == null || request.getStrokeId().isBlank())) {
             throw new DrawingException(DrawingErrorCode.STROKE_ID_REQUIRED);
         }
 
-        // ADD 타입은 strokeData 필수
         if (type == DrawingMessageType.ADD
                 && (request.getStrokeData() == null || request.getStrokeData().isBlank())) {
             throw new DrawingException(DrawingErrorCode.STROKE_DATA_REQUIRED);
         }
 
-        // strokeData 크기 검증
         if (request.getStrokeData() != null
                 && request.getStrokeData().length() > MAX_STROKE_DATA_LENGTH) {
             throw new DrawingException(DrawingErrorCode.STROKE_DATA_TOO_LARGE);

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * 드로잉 비즈니스 로직 서비스
@@ -31,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 public class DrawingService {
 
     private static final String BUFFER_KEY_PREFIX = "drawing:buffer:";
-    private static final long BUFFER_TTL_SECONDS = 3600; // 1 hour
+    private static final String VERSION_KEY_PREFIX = "drawing:version:";
     private static final int MAX_STROKE_DATA_LENGTH = 100000;
 
     private final RoomRepository roomRepository;
@@ -58,6 +57,9 @@ public class DrawingService {
         Member sender = memberRepository.findById(memberId)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
 
+        // 서버에서 버전 할당 (Redis INCR)
+        Long version = assignVersion(roomUuid, request.getPageIndex());
+
         DrawingStrokeDto strokeDto = DrawingStrokeDto.of(
                 roomUuid,
                 sender.getId(),
@@ -66,7 +68,7 @@ public class DrawingService {
                 request.getPageIndex(),
                 request.getStrokeId(),
                 request.getStrokeData(),
-                request.getVersion()
+                version
         );
 
         // Redis List에 버퍼링 (페이지별 분리)
@@ -147,17 +149,45 @@ public class DrawingService {
     }
 
     /**
-     * 스트로크를 Redis List에 버퍼링
+     * Redis INCR을 사용하여 버전 할당
+     */
+    private Long assignVersion(String roomUuid, Integer pageIndex) {
+        try {
+            String versionKey = buildVersionKey(roomUuid, pageIndex);
+            Long version = drawingRedisTemplate.opsForValue().increment(versionKey);
+
+            if (version == null) {
+                throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
+            }
+
+            log.debug("버전 할당: roomUuid={}, pageIndex={}, version={}",
+                    roomUuid, pageIndex, version);
+
+            return version;
+        } catch (Exception e) {
+            log.error("버전 할당 실패: roomUuid={}, pageIndex={}", roomUuid, pageIndex, e);
+            throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    /**
+     * 스트로크를 Redis List에 버퍼링 (TTL 없음 - 스냅샷 저장 시까지 유지)
      */
     private void bufferStroke(String roomUuid, Integer pageIndex, DrawingStrokeDto strokeDto) {
         try {
             String bufferKey = buildBufferKey(roomUuid, pageIndex);
             drawingRedisTemplate.opsForList().rightPush(bufferKey, strokeDto);
-            drawingRedisTemplate.expire(bufferKey, BUFFER_TTL_SECONDS, TimeUnit.SECONDS);
         } catch (Exception e) {
             log.error("Redis 버퍼링 실패: roomUuid={}, pageIndex={}", roomUuid, pageIndex, e);
             throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
         }
+    }
+
+    /**
+     * Redis 버전 키 생성
+     */
+    private String buildVersionKey(String roomUuid, Integer pageIndex) {
+        return VERSION_KEY_PREFIX + roomUuid + ":page:" + pageIndex;
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -6,8 +6,10 @@ import com.writingboard.server.domain.drawing.enums.DrawingMessageType;
 import com.writingboard.server.domain.drawing.exception.DrawingErrorCode;
 import com.writingboard.server.domain.drawing.exception.DrawingException;
 import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.RoomAsset;
 import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
 import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
+import com.writingboard.server.domain.meeting.repository.RoomAssetRepository;
 import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
 import com.writingboard.server.domain.meeting.repository.RoomRepository;
 import com.writingboard.server.domain.member.entity.Member;
@@ -34,6 +36,7 @@ public class DrawingService {
     private static final int MAX_STROKE_DATA_LENGTH = 100000;
 
     private final RoomRepository roomRepository;
+    private final RoomAssetRepository roomAssetRepository;
     private final RoomParticipantRepository participantRepository;
     private final MemberRepository memberRepository;
     private final DrawingRedisPublisher drawingRedisPublisher;
@@ -52,16 +55,20 @@ public class DrawingService {
             throw new DrawingException(DrawingErrorCode.ROOM_CLOSED);
         }
 
+        // RoomAsset 검증 (roomAssetId가 해당 room에 속하는지 확인)
+        RoomAsset roomAsset = validateRoomAsset(room.getId(), request.getRoomAssetId());
+
         validateParticipant(room.getId(), memberId);
 
         Member sender = memberRepository.findById(memberId)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
 
         // 서버에서 버전 할당 (Redis INCR)
-        Long version = assignVersion(roomUuid, request.getPageIndex());
+        Long version = assignVersion(roomUuid, request.getRoomAssetId(), request.getPageIndex());
 
         DrawingStrokeDto strokeDto = DrawingStrokeDto.of(
                 roomUuid,
+                request.getRoomAssetId(),
                 sender.getId(),
                 sender.getName(),
                 request.getType(),
@@ -71,39 +78,39 @@ public class DrawingService {
                 version
         );
 
-        // Redis List에 버퍼링 (페이지별 분리)
-        bufferStroke(roomUuid, request.getPageIndex(), strokeDto);
+        // Redis List에 버퍼링 (asset + 페이지별 분리)
+        bufferStroke(roomUuid, request.getRoomAssetId(), request.getPageIndex(), strokeDto);
 
         // Redis Pub/Sub로 실시간 브로드캐스트
         drawingRedisPublisher.publish(roomUuid, strokeDto);
 
-        log.debug("드로잉 스트로크 전송 완료: roomUuid={}, senderId={}, type={}, pageIndex={}",
-                roomUuid, memberId, request.getType(), request.getPageIndex());
+        log.debug("드로잉 스트로크 전송 완료: roomUuid={}, roomAssetId={}, senderId={}, type={}, pageIndex={}",
+                roomUuid, request.getRoomAssetId(), memberId, request.getType(), request.getPageIndex());
 
         return strokeDto;
     }
 
     /**
-     * 특정 페이지의 스트로크 히스토리 조회
+     * 특정 RoomAsset 페이지의 스트로크 히스토리 조회
      */
-    public List<DrawingStrokeDto> getStrokeHistory(String roomUuid, Integer pageIndex) {
-        String bufferKey = buildBufferKey(roomUuid, pageIndex);
+    public List<DrawingStrokeDto> getStrokeHistory(String roomUuid, Long roomAssetId, Integer pageIndex) {
+        String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
         List<DrawingStrokeDto> strokes = drawingRedisTemplate.opsForList().range(bufferKey, 0, -1);
 
-        log.debug("스트로크 히스토리 조회: roomUuid={}, pageIndex={}, count={}",
-                roomUuid, pageIndex, strokes != null ? strokes.size() : 0);
+        log.debug("스트로크 히스토리 조회: roomUuid={}, roomAssetId={}, pageIndex={}, count={}",
+                roomUuid, roomAssetId, pageIndex, strokes != null ? strokes.size() : 0);
 
         return strokes != null ? strokes : List.of();
     }
 
     /**
-     * 특정 페이지의 스트로크 버퍼 초기화
+     * 특정 RoomAsset 페이지의 스트로크 버퍼 초기화
      */
-    public void clearStrokes(String roomUuid, Integer pageIndex) {
-        String bufferKey = buildBufferKey(roomUuid, pageIndex);
+    public void clearStrokes(String roomUuid, Long roomAssetId, Integer pageIndex) {
+        String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
         drawingRedisTemplate.delete(bufferKey);
 
-        log.debug("스트로크 버퍼 초기화: roomUuid={}, pageIndex={}", roomUuid, pageIndex);
+        log.debug("스트로크 버퍼 초기화: roomUuid={}, roomAssetId={}, pageIndex={}", roomUuid, roomAssetId, pageIndex);
     }
 
     /**
@@ -138,6 +145,15 @@ public class DrawingService {
     }
 
     /**
+     * RoomAsset 검증 (roomAssetId가 해당 room에 속하는지 확인)
+     */
+    private RoomAsset validateRoomAsset(Long roomId, Long roomAssetId) {
+        return roomAssetRepository.findById(roomAssetId)
+                .filter(asset -> asset.getRoom().getId().equals(roomId))
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.ROOM_ASSET_NOT_FOUND));
+    }
+
+    /**
      * 참여자 검증
      */
     private void validateParticipant(Long roomId, Long memberId) {
@@ -152,21 +168,22 @@ public class DrawingService {
     /**
      * Redis INCR을 사용하여 버전 할당
      */
-    private Long assignVersion(String roomUuid, Integer pageIndex) {
+    private Long assignVersion(String roomUuid, Long roomAssetId, Integer pageIndex) {
         try {
-            String versionKey = buildVersionKey(roomUuid, pageIndex);
+            String versionKey = buildVersionKey(roomUuid, roomAssetId, pageIndex);
             Long version = drawingRedisTemplate.opsForValue().increment(versionKey);
 
             if (version == null) {
                 throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
             }
 
-            log.debug("버전 할당: roomUuid={}, pageIndex={}, version={}",
-                    roomUuid, pageIndex, version);
+            log.debug("버전 할당: roomUuid={}, roomAssetId={}, pageIndex={}, version={}",
+                    roomUuid, roomAssetId, pageIndex, version);
 
             return version;
         } catch (Exception e) {
-            log.error("버전 할당 실패: roomUuid={}, pageIndex={}", roomUuid, pageIndex, e);
+            log.error("버전 할당 실패: roomUuid={}, roomAssetId={}, pageIndex={}",
+                    roomUuid, roomAssetId, pageIndex, e);
             throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
         }
     }
@@ -174,27 +191,30 @@ public class DrawingService {
     /**
      * 스트로크를 Redis List에 버퍼링 (TTL 없음 - 스냅샷 저장 시까지 유지)
      */
-    private void bufferStroke(String roomUuid, Integer pageIndex, DrawingStrokeDto strokeDto) {
+    private void bufferStroke(String roomUuid, Long roomAssetId, Integer pageIndex, DrawingStrokeDto strokeDto) {
         try {
-            String bufferKey = buildBufferKey(roomUuid, pageIndex);
+            String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
             drawingRedisTemplate.opsForList().rightPush(bufferKey, strokeDto);
         } catch (Exception e) {
-            log.error("Redis 버퍼링 실패: roomUuid={}, pageIndex={}", roomUuid, pageIndex, e);
+            log.error("Redis 버퍼링 실패: roomUuid={}, roomAssetId={}, pageIndex={}",
+                    roomUuid, roomAssetId, pageIndex, e);
             throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
         }
     }
 
     /**
      * Redis 버전 키 생성
+     * Pattern: drawing:version:room:{roomUuid}:asset:{roomAssetId}:page:{pageIndex}
      */
-    private String buildVersionKey(String roomUuid, Integer pageIndex) {
-        return VERSION_KEY_PREFIX + roomUuid + ":page:" + pageIndex;
+    private String buildVersionKey(String roomUuid, Long roomAssetId, Integer pageIndex) {
+        return VERSION_KEY_PREFIX + "room:" + roomUuid + ":asset:" + roomAssetId + ":page:" + pageIndex;
     }
 
     /**
      * Redis 버퍼 키 생성
+     * Pattern: drawing:buffer:room:{roomUuid}:asset:{roomAssetId}:page:{pageIndex}
      */
-    private String buildBufferKey(String roomUuid, Integer pageIndex) {
-        return BUFFER_KEY_PREFIX + roomUuid + ":page:" + pageIndex;
+    private String buildBufferKey(String roomUuid, Long roomAssetId, Integer pageIndex) {
+        return BUFFER_KEY_PREFIX + "room:" + roomUuid + ":asset:" + roomAssetId + ":page:" + pageIndex;
     }
 }

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -108,9 +108,15 @@ public class DrawingService {
 
     /**
      * 스트로크 요청 데이터 검증
+     * WebSocket으로는 ADD, REMOVE만 허용 (SNAPSHOT은 REST API 사용)
      */
     private void validateStrokeRequest(DrawingStrokeRequest request) {
         DrawingMessageType type = request.getType();
+
+        // SNAPSHOT 타입은 WebSocket으로 받지 않음 (REST API 전용)
+        if (type == DrawingMessageType.SNAPSHOT) {
+            throw new DrawingException(DrawingErrorCode.INVALID_MESSAGE_TYPE);
+        }
 
         // ADD, REMOVE 타입은 strokeId 필수
         if ((type == DrawingMessageType.ADD || type == DrawingMessageType.REMOVE)
@@ -118,15 +124,10 @@ public class DrawingService {
             throw new DrawingException(DrawingErrorCode.STROKE_ID_REQUIRED);
         }
 
-        // ADD, SNAPSHOT 타입은 strokeData 필수
-        if ((type == DrawingMessageType.ADD || type == DrawingMessageType.SNAPSHOT)
+        // ADD 타입은 strokeData 필수
+        if (type == DrawingMessageType.ADD
                 && (request.getStrokeData() == null || request.getStrokeData().isBlank())) {
             throw new DrawingException(DrawingErrorCode.STROKE_DATA_REQUIRED);
-        }
-
-        // SNAPSHOT 타입은 version 필수
-        if (type == DrawingMessageType.SNAPSHOT && request.getVersion() == null) {
-            throw new DrawingException(DrawingErrorCode.VERSION_REQUIRED);
         }
 
         // strokeData 크기 검증

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -1,0 +1,169 @@
+package com.writingboard.server.domain.drawing.service;
+
+import com.writingboard.server.domain.drawing.dto.request.DrawingStrokeRequest;
+import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
+import com.writingboard.server.domain.drawing.enums.DrawingMessageType;
+import com.writingboard.server.domain.drawing.exception.DrawingErrorCode;
+import com.writingboard.server.domain.drawing.exception.DrawingException;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 드로잉 비즈니스 로직 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DrawingService {
+
+    private static final String BUFFER_KEY_PREFIX = "drawing:buffer:";
+    private static final long BUFFER_TTL_SECONDS = 3600; // 1 hour
+    private static final int MAX_STROKE_DATA_LENGTH = 100000;
+
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
+    private final MemberRepository memberRepository;
+    private final DrawingRedisPublisher drawingRedisPublisher;
+    private final RedisTemplate<String, DrawingStrokeDto> drawingRedisTemplate;
+
+    /**
+     * 드로잉 스트로크 전송
+     */
+    public DrawingStrokeDto sendStroke(Long memberId, String roomUuid, DrawingStrokeRequest request) {
+        validateStrokeRequest(request);
+
+        Room room = roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.ROOM_NOT_FOUND));
+
+        if (room.getStatus() != RoomStatus.OPEN) {
+            throw new DrawingException(DrawingErrorCode.ROOM_CLOSED);
+        }
+
+        validateParticipant(room.getId(), memberId);
+
+        Member sender = memberRepository.findById(memberId)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
+
+        DrawingStrokeDto strokeDto = DrawingStrokeDto.of(
+                roomUuid,
+                sender.getId(),
+                sender.getName(),
+                request.getType(),
+                request.getPageIndex(),
+                request.getStrokeId(),
+                request.getStrokeData(),
+                request.getVersion()
+        );
+
+        // Redis List에 버퍼링 (페이지별 분리)
+        bufferStroke(roomUuid, request.getPageIndex(), strokeDto);
+
+        // Redis Pub/Sub로 실시간 브로드캐스트
+        drawingRedisPublisher.publish(roomUuid, strokeDto);
+
+        log.debug("드로잉 스트로크 전송 완료: roomUuid={}, senderId={}, type={}, pageIndex={}",
+                roomUuid, memberId, request.getType(), request.getPageIndex());
+
+        return strokeDto;
+    }
+
+    /**
+     * 특정 페이지의 스트로크 히스토리 조회
+     */
+    public List<DrawingStrokeDto> getStrokeHistory(String roomUuid, Integer pageIndex) {
+        String bufferKey = buildBufferKey(roomUuid, pageIndex);
+        List<DrawingStrokeDto> strokes = drawingRedisTemplate.opsForList().range(bufferKey, 0, -1);
+
+        log.debug("스트로크 히스토리 조회: roomUuid={}, pageIndex={}, count={}",
+                roomUuid, pageIndex, strokes != null ? strokes.size() : 0);
+
+        return strokes != null ? strokes : List.of();
+    }
+
+    /**
+     * 특정 페이지의 스트로크 버퍼 초기화
+     */
+    public void clearStrokes(String roomUuid, Integer pageIndex) {
+        String bufferKey = buildBufferKey(roomUuid, pageIndex);
+        drawingRedisTemplate.delete(bufferKey);
+
+        log.debug("스트로크 버퍼 초기화: roomUuid={}, pageIndex={}", roomUuid, pageIndex);
+    }
+
+    /**
+     * 스트로크 요청 데이터 검증
+     */
+    private void validateStrokeRequest(DrawingStrokeRequest request) {
+        DrawingMessageType type = request.getType();
+
+        // ADD, REMOVE 타입은 strokeId 필수
+        if ((type == DrawingMessageType.ADD || type == DrawingMessageType.REMOVE)
+                && (request.getStrokeId() == null || request.getStrokeId().isBlank())) {
+            throw new DrawingException(DrawingErrorCode.STROKE_ID_REQUIRED);
+        }
+
+        // ADD, SNAPSHOT 타입은 strokeData 필수
+        if ((type == DrawingMessageType.ADD || type == DrawingMessageType.SNAPSHOT)
+                && (request.getStrokeData() == null || request.getStrokeData().isBlank())) {
+            throw new DrawingException(DrawingErrorCode.STROKE_DATA_REQUIRED);
+        }
+
+        // SNAPSHOT 타입은 version 필수
+        if (type == DrawingMessageType.SNAPSHOT && request.getVersion() == null) {
+            throw new DrawingException(DrawingErrorCode.VERSION_REQUIRED);
+        }
+
+        // strokeData 크기 검증
+        if (request.getStrokeData() != null
+                && request.getStrokeData().length() > MAX_STROKE_DATA_LENGTH) {
+            throw new DrawingException(DrawingErrorCode.STROKE_DATA_TOO_LARGE);
+        }
+    }
+
+    /**
+     * 참여자 검증
+     */
+    private void validateParticipant(Long roomId, Long memberId) {
+        boolean isParticipant = participantRepository.existsByRoomIdAndMemberIdAndState(
+                roomId, memberId, ParticipantState.JOINED);
+
+        if (!isParticipant) {
+            throw new DrawingException(DrawingErrorCode.NOT_PARTICIPANT);
+        }
+    }
+
+    /**
+     * 스트로크를 Redis List에 버퍼링
+     */
+    private void bufferStroke(String roomUuid, Integer pageIndex, DrawingStrokeDto strokeDto) {
+        try {
+            String bufferKey = buildBufferKey(roomUuid, pageIndex);
+            drawingRedisTemplate.opsForList().rightPush(bufferKey, strokeDto);
+            drawingRedisTemplate.expire(bufferKey, BUFFER_TTL_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("Redis 버퍼링 실패: roomUuid={}, pageIndex={}", roomUuid, pageIndex, e);
+            throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    /**
+     * Redis 버퍼 키 생성
+     */
+    private String buildBufferKey(String roomUuid, Integer pageIndex) {
+        return BUFFER_KEY_PREFIX + roomUuid + ":page:" + pageIndex;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -141,8 +141,7 @@ public class DrawingService {
      * RoomAsset 검증 (roomAssetId가 해당 room에 속하는지 확인)
      */
     private RoomAsset validateRoomAsset(Long roomId, Long roomAssetId) {
-        return roomAssetRepository.findById(roomAssetId)
-                .filter(asset -> asset.getRoom().getId().equals(roomId))
+        return roomAssetRepository.findByIdAndRoomId(roomAssetId, roomId)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.ROOM_ASSET_NOT_FOUND));
     }
 

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -26,7 +26,6 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class DrawingService {
 
     private static final String BUFFER_KEY_PREFIX = "drawing:buffer:";
@@ -43,6 +42,7 @@ public class DrawingService {
     /**
      * 드로잉 스트로크 전송
      */
+    @Transactional(readOnly = true)
     public DrawingStrokeDto sendStroke(Long memberId, String roomUuid, DrawingStrokeRequest request) {
         validateStrokeRequest(request);
 
@@ -88,6 +88,7 @@ public class DrawingService {
     /**
      * 특정 RoomAsset 페이지의 스트로크 히스토리 조회
      */
+    @Transactional(readOnly = true)
     public List<DrawingStrokeDto> getStrokeHistory(String roomUuid, Long roomAssetId, Integer pageIndex) {
         String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
         List<DrawingStrokeDto> strokes = drawingRedisTemplate.opsForList().range(bufferKey, 0, -1);
@@ -101,6 +102,7 @@ public class DrawingService {
     /**
      * 특정 RoomAsset 페이지의 스트로크 버퍼 초기화
      */
+    @Transactional(readOnly = true)
     public void clearStrokes(String roomUuid, Long roomAssetId, Integer pageIndex) {
         String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
         drawingRedisTemplate.delete(bufferKey);

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -1,0 +1,98 @@
+package com.writingboard.server.domain.drawing.service;
+
+import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
+import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
+import com.writingboard.server.domain.drawing.exception.DrawingErrorCode;
+import com.writingboard.server.domain.drawing.exception.DrawingException;
+import com.writingboard.server.domain.drawing.repository.DrawingSnapshotRepository;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 드로잉 스냅샷 서비스
+ * MongoDB 저장 및 Redis 버퍼 정리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DrawingSnapshotService {
+
+    private static final String BUFFER_KEY_PREFIX = "drawing:buffer:";
+
+    private final DrawingSnapshotRepository snapshotRepository;
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, DrawingStrokeDto> drawingRedisTemplate;
+
+    /**
+     * 스냅샷 저장 및 Redis 버퍼 정리
+     */
+    @Transactional
+    public DrawingSnapshot saveSnapshot(Long memberId, String roomUuid, Integer pageIndex,
+                                       Long lastIncludedVersion, String snapshotData) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
+
+        // 스냅샷 저장
+        DrawingSnapshot snapshot = DrawingSnapshot.create(
+                roomUuid, pageIndex, lastIncludedVersion, snapshotData,
+                member.getId(), member.getName()
+        );
+
+        DrawingSnapshot saved = snapshotRepository.save(snapshot);
+
+        log.info("스냅샷 저장 완료: roomUuid={}, pageIndex={}, version={}",
+                roomUuid, pageIndex, lastIncludedVersion);
+
+        // Redis 버퍼 정리 (LTRIM)
+        trimRedisBuffer(roomUuid, pageIndex, lastIncludedVersion);
+
+        return saved;
+    }
+
+    /**
+     * 특정 페이지의 최신 스냅샷 조회
+     */
+    public Optional<DrawingSnapshot> getLatestSnapshot(String roomUuid, Integer pageIndex) {
+        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "version"));
+        return snapshotRepository.findLatestByRoomUuidAndPageIndex(roomUuid, pageIndex, pageRequest);
+    }
+
+    /**
+     * Redis 버퍼 정리 (LTRIM)
+     * lastIncludedVersion까지의 스트로크를 제거
+     */
+    private void trimRedisBuffer(String roomUuid, Integer pageIndex, Long lastIncludedVersion) {
+        String bufferKey = buildBufferKey(roomUuid, pageIndex);
+
+        try {
+            // LTRIM: 인덱스 lastIncludedVersion 이후부터 끝까지 유지
+            // 예: version 1-50이 저장됨 → LTRIM key 50 -1 (인덱스 50부터 끝까지 유지)
+            drawingRedisTemplate.opsForList().trim(bufferKey, lastIncludedVersion, -1);
+
+            log.info("Redis 버퍼 정리 완료: bufferKey={}, trimmedUpTo={}",
+                    bufferKey, lastIncludedVersion);
+
+        } catch (Exception e) {
+            log.error("Redis 버퍼 정리 실패: bufferKey={}, version={}",
+                    bufferKey, lastIncludedVersion, e);
+            // 정리 실패해도 스냅샷은 저장되었으므로 예외를 던지지 않음
+        }
+    }
+
+    /**
+     * Redis 버퍼 키 생성
+     */
+    private String buildBufferKey(String roomUuid, Integer pageIndex) {
+        return BUFFER_KEY_PREFIX + roomUuid + ":page:" + pageIndex;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -36,11 +36,21 @@ public class DrawingSnapshotService {
      */
     @Transactional
     public DrawingSnapshot saveSnapshot(Long memberId, String roomUuid, Long roomAssetId, Integer pageIndex,
-                                       Long lastIncludedVersion, String snapshotData) {
+                                        Long lastIncludedVersion, String snapshotData) {
+
+
+        Optional<DrawingSnapshot> latestSnapshot = getLatestSnapshot(roomAssetId, pageIndex);
+
+        if (latestSnapshot.isPresent() && latestSnapshot.get().getVersion() >= lastIncludedVersion) {
+            log.info("이미 최신 스냅샷이 존재하여 저장을 건너뜁니다. (Current: {}, Incoming: {})",
+                    latestSnapshot.get().getVersion(), lastIncludedVersion);
+            return latestSnapshot.get();
+        }
+
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
 
-        // 스냅샷 저장
         DrawingSnapshot snapshot = DrawingSnapshot.create(
                 roomUuid, roomAssetId, pageIndex, lastIncludedVersion, snapshotData,
                 member.getId(), member.getName()
@@ -51,7 +61,6 @@ public class DrawingSnapshotService {
         log.info("스냅샷 저장 완료: roomUuid={}, roomAssetId={}, pageIndex={}, version={}",
                 roomUuid, roomAssetId, pageIndex, lastIncludedVersion);
 
-        // Redis 버퍼 정리 (LTRIM)
         trimRedisBuffer(roomUuid, roomAssetId, pageIndex, lastIncludedVersion);
 
         return saved;
@@ -66,30 +75,18 @@ public class DrawingSnapshotService {
 
     /**
      * Redis 버퍼 정리 (LTRIM)
-     * lastIncludedVersion까지의 스트로크를 제거
      */
     private void trimRedisBuffer(String roomUuid, Long roomAssetId, Integer pageIndex, Long lastIncludedVersion) {
         String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
 
         try {
-            // LTRIM: 인덱스 lastIncludedVersion 이후부터 끝까지 유지
-            // 예: version 1-50이 저장됨 → LTRIM key 50 -1 (인덱스 50부터 끝까지 유지)
             drawingRedisTemplate.opsForList().trim(bufferKey, lastIncludedVersion, -1);
-
-            log.info("Redis 버퍼 정리 완료: bufferKey={}, trimmedUpTo={}",
-                    bufferKey, lastIncludedVersion);
-
+            log.info("Redis 버퍼 정리 완료: bufferKey={}, trimmedUpTo={}", bufferKey, lastIncludedVersion);
         } catch (Exception e) {
-            log.error("Redis 버퍼 정리 실패: bufferKey={}, version={}",
-                    bufferKey, lastIncludedVersion, e);
-            // 정리 실패해도 스냅샷은 저장되었으므로 예외를 던지지 않음
+            log.error("Redis 버퍼 정리 실패: bufferKey={}, version={}", bufferKey, lastIncludedVersion, e);
         }
     }
 
-    /**
-     * Redis 버퍼 키 생성
-     * Pattern: drawing:buffer:room:{roomUuid}:asset:{roomAssetId}:page:{pageIndex}
-     */
     private String buildBufferKey(String roomUuid, Long roomAssetId, Integer pageIndex) {
         return BUFFER_KEY_PREFIX + "room:" + roomUuid + ":asset:" + roomAssetId + ":page:" + pageIndex;
     }

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -35,41 +35,41 @@ public class DrawingSnapshotService {
      * 스냅샷 저장 및 Redis 버퍼 정리
      */
     @Transactional
-    public DrawingSnapshot saveSnapshot(Long memberId, String roomUuid, Integer pageIndex,
+    public DrawingSnapshot saveSnapshot(Long memberId, String roomUuid, Long roomAssetId, Integer pageIndex,
                                        Long lastIncludedVersion, String snapshotData) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
 
         // 스냅샷 저장
         DrawingSnapshot snapshot = DrawingSnapshot.create(
-                roomUuid, pageIndex, lastIncludedVersion, snapshotData,
+                roomUuid, roomAssetId, pageIndex, lastIncludedVersion, snapshotData,
                 member.getId(), member.getName()
         );
 
         DrawingSnapshot saved = snapshotRepository.save(snapshot);
 
-        log.info("스냅샷 저장 완료: roomUuid={}, pageIndex={}, version={}",
-                roomUuid, pageIndex, lastIncludedVersion);
+        log.info("스냅샷 저장 완료: roomUuid={}, roomAssetId={}, pageIndex={}, version={}",
+                roomUuid, roomAssetId, pageIndex, lastIncludedVersion);
 
         // Redis 버퍼 정리 (LTRIM)
-        trimRedisBuffer(roomUuid, pageIndex, lastIncludedVersion);
+        trimRedisBuffer(roomUuid, roomAssetId, pageIndex, lastIncludedVersion);
 
         return saved;
     }
 
     /**
-     * 특정 캔버스 페이지의 최신 스냅샷 조회
+     * 특정 RoomAsset 페이지의 최신 스냅샷 조회
      */
-    public Optional<DrawingSnapshot> getLatestSnapshot(String roomUuid, Integer pageIndex) {
-        return snapshotRepository.findFirstByRoomUuidAndPageIndexOrderByVersionDesc(roomUuid, pageIndex);
+    public Optional<DrawingSnapshot> getLatestSnapshot(Long roomAssetId, Integer pageIndex) {
+        return snapshotRepository.findFirstByRoomAssetIdAndPageIndexOrderByVersionDesc(roomAssetId, pageIndex);
     }
 
     /**
      * Redis 버퍼 정리 (LTRIM)
      * lastIncludedVersion까지의 스트로크를 제거
      */
-    private void trimRedisBuffer(String roomUuid, Integer pageIndex, Long lastIncludedVersion) {
-        String bufferKey = buildBufferKey(roomUuid, pageIndex);
+    private void trimRedisBuffer(String roomUuid, Long roomAssetId, Integer pageIndex, Long lastIncludedVersion) {
+        String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
 
         try {
             // LTRIM: 인덱스 lastIncludedVersion 이후부터 끝까지 유지
@@ -88,8 +88,9 @@ public class DrawingSnapshotService {
 
     /**
      * Redis 버퍼 키 생성
+     * Pattern: drawing:buffer:room:{roomUuid}:asset:{roomAssetId}:page:{pageIndex}
      */
-    private String buildBufferKey(String roomUuid, Integer pageIndex) {
-        return BUFFER_KEY_PREFIX + roomUuid + ":page:" + pageIndex;
+    private String buildBufferKey(String roomUuid, Long roomAssetId, Integer pageIndex) {
+        return BUFFER_KEY_PREFIX + "room:" + roomUuid + ":asset:" + roomAssetId + ":page:" + pageIndex;
     }
 }

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class DrawingSnapshotService {
 
     private static final String BUFFER_KEY_PREFIX = "drawing:buffer:";
@@ -66,6 +65,7 @@ public class DrawingSnapshotService {
     /**
      * 특정 RoomAsset 페이지의 최신 스냅샷 조회
      */
+    @Transactional(readOnly = true)
     public Optional<DrawingSnapshot> getLatestSnapshot(Long roomAssetId, Integer pageIndex) {
         return snapshotRepository.findFirstByRoomAssetIdAndPageIndexOrderByVersionDesc(roomAssetId, pageIndex);
     }

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -15,10 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-/**
- * 드로잉 스냅샷 서비스
- * MongoDB 저장 및 Redis 버퍼 정리
- */
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -74,7 +71,7 @@ public class DrawingSnapshotService {
     }
 
     /**
-     * Redis 버퍼 정리 (LTRIM)
+     * Redis 버퍼 정리
      */
     private void trimRedisBuffer(String roomUuid, Long roomAssetId, Integer pageIndex, Long lastIncludedVersion) {
         String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -9,8 +9,6 @@ import com.writingboard.server.domain.member.entity.Member;
 import com.writingboard.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,11 +58,10 @@ public class DrawingSnapshotService {
     }
 
     /**
-     * 특정 페이지의 최신 스냅샷 조회
+     * 특정 캔버스 페이지의 최신 스냅샷 조회
      */
     public Optional<DrawingSnapshot> getLatestSnapshot(String roomUuid, Integer pageIndex) {
-        PageRequest pageRequest = PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "version"));
-        return snapshotRepository.findLatestByRoomUuidAndPageIndex(roomUuid, pageIndex, pageRequest);
+        return snapshotRepository.findFirstByRoomUuidAndPageIndexOrderByVersionDesc(roomUuid, pageIndex);
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Deprecated
 @RestController
 @RequestMapping("/api/rooms/{roomUuid}/canvas")
 @RequiredArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasFollowController.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/controller/CanvasFollowController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Deprecated
 @RestController
 @RequestMapping("/api/rooms/{roomUuid}/follow")
 @RequiredArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/request/CanvasUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/request/CanvasUpdateRequest.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Deprecated
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasPageResponse.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasPageResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import java.time.Instant;
 import java.util.Base64;
 
+@Deprecated
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasSnapshotResponse.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/dto/response/CanvasSnapshotResponse.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 
 import java.time.Instant;
 
+@Deprecated
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasPage.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasPage.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
+@Deprecated
 @Entity
 @Table(name = "canvas_page", uniqueConstraints = {
         @UniqueConstraint(name = "uk_canvas_page_asset_index", columnNames = {"room_asset_id", "page_index"})

--- a/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasSnapshot.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/entity/CanvasSnapshot.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
+@Deprecated
 @Entity
 @Table(name = "canvas_snapshot", indexes = {
         @Index(name = "idx_canvas_snapshot_asset_page", columnList = "room_asset_id, page_index")

--- a/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowRedisPublisher.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+@Deprecated
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/CanvasFollowService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Deprecated
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/writingboard/server/domain/meeting/service/CanvasService.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/service/CanvasService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Base64;
 
+@Deprecated
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.writingboard.server.domain.chat.dto.response.ChatMessageDto;
 import com.writingboard.server.domain.chat.service.ChatRedisSubscriber;
+import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
+import com.writingboard.server.domain.drawing.service.DrawingRedisSubscriber;
 import com.writingboard.server.domain.meeting.dto.FollowStateDto;
 import com.writingboard.server.domain.meeting.service.FollowRedisSubscriber;
 import com.writingboard.server.domain.voice.dto.response.VoiceSignalDto;
@@ -24,6 +26,7 @@ public class RedisPubSubConfig {
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory redisConnectionFactory,
             ChatRedisSubscriber chatRedisSubscriber,
+            DrawingRedisSubscriber drawingRedisSubscriber,
             VoiceRedisSubscriber voiceRedisSubscriber,
             FollowRedisSubscriber followRedisSubscriber) {
 
@@ -35,6 +38,9 @@ public class RedisPubSubConfig {
 
         // voice:room:* 패턴의 모든 채널 구독
         container.addMessageListener(voiceRedisSubscriber, new PatternTopic("voice:room:*"));
+
+        // drawing:room:* 패턴의 모든 채널 구독
+        container.addMessageListener(drawingRedisSubscriber, new PatternTopic("drawing:room:*"));
 
         // follow:room:* 패턴의 모든 채널 구독
         container.addMessageListener(followRedisSubscriber, new PatternTopic("follow:room:*"));
@@ -75,6 +81,26 @@ public class RedisPubSubConfig {
 
         Jackson2JsonRedisSerializer<VoiceSignalDto> serializer =
                 new Jackson2JsonRedisSerializer<>(objectMapper, VoiceSignalDto.class);
+
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, DrawingStrokeDto> drawingRedisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, DrawingStrokeDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        Jackson2JsonRedisSerializer<DrawingStrokeDto> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, DrawingStrokeDto.class);
 
         template.setValueSerializer(serializer);
         template.afterPropertiesSet();

--- a/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
@@ -34,8 +34,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOriginPatterns("*")
-                .addInterceptors(new JwtHandshakeInterceptor(jwtProvider))
-                .withSockJS();
+                .addInterceptors(new JwtHandshakeInterceptor(jwtProvider));
     }
 
     @Override

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.writingboard.server.global.exception;
 
 import com.writingboard.server.domain.auth.exception.AuthException;
 import com.writingboard.server.domain.chat.exception.ChatException;
+import com.writingboard.server.domain.drawing.exception.DrawingException;
 import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.member.exception.MemberException;
 import com.writingboard.server.domain.personal.exception.PersonalException;
@@ -46,6 +47,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(VoiceException.class)
     public ResponseEntity<ErrorResponse> handleVoiceException(VoiceException e) {
         log.warn("VoiceException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(DrawingException.class)
+    public ResponseEntity<ErrorResponse> handleDrawingException(DrawingException e) {
+        log.warn("DrawingException: {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
     properties:
       hibernate:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,5 +31,5 @@ logging:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-expiration: 1800000   # 30분 (ms 단위)
+  access-expiration: 7200000   # 2hours (ms 단위)
   refresh-expiration: 604800000 # 7일 (ms 단위)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,10 +1,36 @@
 spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ${REDIS_PASSWORD}
+    mongodb:
+      uri: ${MONGO_URI}
+
   datasource:
-    url: ${DB_URL}           # 배포할 때 주입
+    url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: validate     # 배포 환경 안전장치
+      ddl-auto: validate
     show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+logging:
+  level:
+    org.hibernate.SQL: warn
+    com.writingboard.server: info
+    org.springframework.messaging: warn
+    org.springframework.web.socket: warn
+    org.springframework.data.mongodb: warn
+    org.springframework.data.redis: warn
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: 7200000
+  refresh-expiration: 604800000


### PR DESCRIPTION
Closes #16

애플 펜슬 기반의 실시간 협업 드로잉을 지원하기 위한 백엔드 인프라 및 동기화 로직을 구현했습니다. 

프론트에서 화면 변화를 감지해 Stroke 단위로 파싱해서,  프론트에 key-value 기반으로 stroke 데이터를 저장하고 uuid를 발급합니다. 
```json
{
  "type": "ADD",        // REMOVE도 가능   
  "roomAssetId": 1,
  "pageIndex": 0,
  "strokeId": "UUID-STR",   
  "strokeData": "BASE64..."
}
```
획 추가할 시 ADD json 1개 보내면 되고, 벡터 지우개는 REMOVE 1개 보내면 됩니다.
(REMOVE는 strokeData 불필요)(픽셀 지우개는 ADD 4개 REMOVE 1개 보내는데 이건 최적화 예정)

레디스 List 버퍼에 해당 json을 임시 저장하고 
서버에서 stroke에 버전을 부여합니다. 

```json
{
  "roomUuid": "...",
  "roomAssetId": 1,
  "senderId": 123,
  "senderName": "User A",
  "type": "ADD",
  "pageIndex": 0,
  "strokeId": "UUID-STR",
  "strokeData": "BASE64...",
  "version": 42,             // 서버 INCR로 부여된 시퀀스
  "timestamp": "2026-02-02T..."
}
```

이런 형식으로 브로드캐스팅하고, 모든 사용자가 이 데이터를 바탕으로 동기화 합니다.

이렇게 하다보면 Redis List에 PKstroke가 쌓이게 되는데, 이 문제를 해결하기 위해 스냅샷 방식을 도입했습니다. 서버에서 PKstorke를 모아서 이걸 스냅샷으로 몽고에 저장하면 좋지만 서버에서 PKstroke를 조햡할 방법이 없기 때문에, 프론트한테 이걸 요청해야됩니다. 프론트는 일정 시간마다 스냅샷을 트리거하고 (일단 지금은 방장만 트리거 하는데 방장 나가는 케이스는 고려 안 함) lastIncludedVersion과 PKdrawing 데이터를 서버로 보냅니다. 서버는 이 lastIncludedversion을 보고 그 버전 이전의 모든 stroke들을 Redis List에서 치운뒤 몽고DB에 저장합니다. 이렇게 하면 스냅샷을 보낸 이후 획을 더 그어도 획이 유실되지 않습니다.

중간참여자는 제일 최근 스냅샷 + 레디스에 남아있는 Stroke로 화면을 구성합니다. 스냅샷은 (roomasset, pageIndex)를 기준으로 제일 최근 1개만 존재해도 되지만 개발 단계에서는 일단 모두 저장했습니다.



1. 실시간 드로잉 동기화 
- Redis INCR을 사용하여 서버에서 원자적으로 버전(v1, v2...)을 부여합니다. 클라이언트 간 동시성 충돌을 방지합니다.
- 모든 ADD/REMOVE 이벤트는 Redis List에 즉시 버퍼링되어 실시간성을 확보합니다.
- 송신자 포함 모든 참여자에게 서버 할당 버전이 포함된 DTO를 브로드캐스트하여 로컬 상태를 확정합니다.

2. 데이터 영속화
- 대량의 스트로크 데이터를 주기적으로 스냅샷(PKDrawing full data) 형태로 몽고DB에 영구 저장합니다.
- 스냅샷은 프론트에서 트리거하며(n초마다 or 몇획마다) 제일 최근 스냅샷과 버전 변화가 없다면 저장하지 않습니다.
- 스냅샷 저장 시점에 LTRIM을 사용하여 Redis 버퍼를 정리합니다.
- 중간 참여 로직: 새로 입장한 유저는 최신 스냅샷(Mongo) + 이후 잔여 버퍼(Redis)를 조합하여 즉시 최신 화면으로 동기화됩니다.


### TODO
room 폭파시 redis 비우기 로직 구현
방장만 스냅샷 보내는거 수정
픽셀 지우개 최적화(이거 안 되면 pencilkit 쓰는 의미가 없음)
한 획 그을 때 db 쿼리 여러번 보내는거 최적화
나중에 redis 장애났을 때 필기데이터 유실되는거 생각하면 redis streams 도입?


Canvas랑 Follow는 임시로 비활성화 했습니다... 나중에 수정해서 적용하겠습니다
아 그리고 테스팅할 때 불편해서 재시작할 때 db 초기화 안 되게 했고 jwt 만료시간 2시간으로 바꿨습니다.

Xcode로 아이패드 2개 띄워서 시뮬레이터 좀 테스트 해봤는데 괜찮게 됩니다.
