### PR TITLE
[FIX]: 팀 삭제 시 TransientObjectException 예외 해결 및 관련 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 dependencyManagement {

--- a/src/main/java/com/writingboard/server/domain/meeting/repository/RoomRepository.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/repository/RoomRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
@@ -28,4 +29,7 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
                                       @Param("status") RoomStatus status,
                                       Pageable pageable);
 
+    List<Room> findAllByTeamId(Long teamId);
+
+    void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamAssetRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamAssetRepository.java
@@ -29,4 +29,6 @@ public interface TeamAssetRepository extends JpaRepository<TeamAsset, Long> {
     List<TeamAsset> findByTeamIdAndStatus(Long teamId, AssetStatus status);
 
     List<TeamAsset> findByStatusAndDeletedAtBeforeAndStorageKeyIsNotNull(AssetStatus status, Instant before);
+
+    void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamInvitationRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamInvitationRepository.java
@@ -20,4 +20,6 @@ public interface TeamInvitationRepository extends JpaRepository<TeamInvitation, 
     boolean existsByTeamIdAndInviteeIdAndStatus(Long teamId, Long inviteeId, TeamInvitationStatus status);
 
     boolean existsByInviteToken(String inviteToken);
+
+    void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamMemberRepository.java
@@ -23,4 +23,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     boolean existsByTeamIdAndMemberIdAndRoleIn(Long teamId, Long memberId, List<TeamRole> roles);
 
     boolean existsByTeamIdAndMemberIdAndStatusAndRoleIn(Long teamId, Long memberId, TeamMemberStatus status, List<TeamRole> roles);
+
+    void deleteAllByTeamId(Long teamId);
 }

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamService.java
@@ -6,6 +6,7 @@ import com.writingboard.server.domain.team.dto.request.TeamCreateRequest;
 import com.writingboard.server.domain.team.dto.request.TeamUpdateRequest;
 import com.writingboard.server.domain.team.dto.response.TeamResponse;
 import com.writingboard.server.domain.team.dto.response.TeamSummaryResponse;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
 import com.writingboard.server.domain.team.entity.Team;
 import com.writingboard.server.domain.team.entity.TeamAsset;
 import com.writingboard.server.domain.team.entity.TeamMember;
@@ -15,6 +16,7 @@ import com.writingboard.server.domain.team.entity.enums.TeamRole;
 import com.writingboard.server.domain.team.exception.TeamErrorCode;
 import com.writingboard.server.domain.team.exception.TeamException;
 import com.writingboard.server.domain.team.repository.TeamAssetRepository;
+import com.writingboard.server.domain.team.repository.TeamInvitationRepository;
 import com.writingboard.server.domain.team.repository.TeamMemberRepository;
 import com.writingboard.server.domain.team.repository.TeamRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,8 @@ public class TeamService {
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final TeamAssetRepository teamAssetRepository;
+    private final TeamInvitationRepository teamInvitationRepository;
+    private final RoomRepository roomRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
@@ -113,13 +117,17 @@ public class TeamService {
         Team team = getTeamById(teamId);
         validateOwner(teamId, memberId);
 
-        // 모든 팀 자산 soft delete
-        List<TeamAsset> assets = teamAssetRepository.findByTeamIdAndStatus(teamId, AssetStatus.ACTIVE);
-        assets.forEach(TeamAsset::delete);
+        // 팀에 속한 모든 회의실 삭제 (cascade로 참가자, 초대, 자산도 삭제)
+        roomRepository.deleteAllByTeamId(teamId);
 
-        // 모든 팀 멤버 상태를 LEFT로 변경
-        List<TeamMember> members = teamMemberRepository.findByTeamIdAndStatus(teamId, TeamMemberStatus.ACTIVE);
-        members.forEach(TeamMember::leave);
+        // 모든 팀 자산 삭제
+        teamAssetRepository.deleteAllByTeamId(teamId);
+
+        // 모든 팀 초대 삭제
+        teamInvitationRepository.deleteAllByTeamId(teamId);
+
+        // 모든 팀 멤버 삭제
+        teamMemberRepository.deleteAllByTeamId(teamId);
 
         teamRepository.delete(team);
     }

--- a/src/test/java/com/writingboard/server/domain/meeting/service/RoomAssetServiceTest.java
+++ b/src/test/java/com/writingboard/server/domain/meeting/service/RoomAssetServiceTest.java
@@ -68,20 +68,20 @@ class RoomAssetServiceTest {
     @BeforeEach
     void setUp() {
         member = mock(Member.class);
-        given(member.getId()).willReturn(MEMBER_ID);
-        given(member.getName()).willReturn("테스터");
+        lenient().when(member.getId()).thenReturn(MEMBER_ID);
+        lenient().when(member.getName()).thenReturn("테스터");
 
         team = mock(Team.class);
-        given(team.getId()).willReturn(1L);
+        lenient().when(team.getId()).thenReturn(1L);
 
         room = mock(Room.class);
-        given(room.getId()).willReturn(1L);
-        given(room.getTeam()).willReturn(team);
+        lenient().when(room.getId()).thenReturn(1L);
+        lenient().when(room.getTeam()).thenReturn(team);
 
         participant = mock(RoomParticipant.class);
-        given(participant.getMember()).willReturn(member);
-        given(participant.getState()).willReturn(ParticipantState.JOINED);
-        given(participant.getRole()).willReturn(ParticipantRole.EDITOR);
+        lenient().when(participant.getMember()).thenReturn(member);
+        lenient().when(participant.getState()).thenReturn(ParticipantState.JOINED);
+        lenient().when(participant.getRole()).thenReturn(ParticipantRole.PARTICIPANT);
 
         teamAsset = TeamAsset.create(team, member, AssetType.PDF, "test.pdf",
                 AssetSourceType.UPLOADED, OLD_STORAGE_KEY, 5);

--- a/src/test/java/com/writingboard/server/domain/team/service/TeamServiceDeleteIntegrationTest.java
+++ b/src/test/java/com/writingboard/server/domain/team/service/TeamServiceDeleteIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.writingboard.server.domain.team.service;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamMember;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.repository.TeamAssetRepository;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
+import jakarta.persistence.EntityManager;
+import org.hibernate.TransientObjectException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("팀 삭제 통합 테스트 - TransientObjectException 재현 및 수정 검증")
+class TeamServiceDeleteIntegrationTest {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+
+    @Autowired
+    private TeamAssetRepository teamAssetRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Member owner;
+    private Team team;
+    private TeamMember ownerMember;
+
+    @BeforeEach
+    void setUp() {
+        owner = Member.createGuest("device-001", "테스트유저");
+        memberRepository.save(owner);
+
+        team = Team.create(owner, "테스트팀", "테스트 설명");
+        teamRepository.save(team);
+
+        ownerMember = TeamMember.createOwner(team, owner);
+        teamMemberRepository.save(ownerMember);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("버그 재현: TeamMember status 변경 후 Team 삭제 시 TransientObjectException 발생")
+    void deleteTeam_기존로직_TransientObjectException_발생() {
+        // given
+        Team foundTeam = teamRepository.findById(team.getId()).orElseThrow();
+        List<TeamMember> members = teamMemberRepository.findByTeamIdAndStatus(
+                foundTeam.getId(), TeamMemberStatus.ACTIVE);
+
+        // when - 기존 로직: status 변경 후 Team 삭제
+        members.forEach(TeamMember::leave);
+        teamRepository.delete(foundTeam);
+
+        // then - flush 시 TransientObjectException 발생
+        assertThatThrownBy(() -> entityManager.flush())
+                .rootCause()
+                .isInstanceOf(TransientObjectException.class);
+    }
+
+    @Test
+    @DisplayName("수정 검증: 자식 엔티티 hard delete 후 Team 삭제 시 정상 동작")
+    void deleteTeam_수정로직_정상삭제() {
+        // given
+        Team foundTeam = teamRepository.findById(team.getId()).orElseThrow();
+
+        // when - 수정된 로직: 자식 엔티티 hard delete 후 Team 삭제
+        teamMemberRepository.deleteAllByTeamId(foundTeam.getId());
+        teamRepository.delete(foundTeam);
+        entityManager.flush();
+
+        // then
+        assertThat(teamRepository.findById(team.getId())).isEmpty();
+        assertThat(teamMemberRepository.findByTeamIdAndStatus(team.getId(), TeamMemberStatus.ACTIVE)).isEmpty();
+    }
+}

--- a/src/test/java/com/writingboard/server/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/com/writingboard/server/domain/team/service/TeamServiceTest.java
@@ -1,0 +1,112 @@
+package com.writingboard.server.domain.team.service;
+
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.entity.enums.TeamRole;
+import com.writingboard.server.domain.team.exception.TeamException;
+import com.writingboard.server.domain.team.repository.TeamAssetRepository;
+import com.writingboard.server.domain.team.repository.TeamInvitationRepository;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TeamService 단위 테스트")
+class TeamServiceTest {
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Mock private TeamRepository teamRepository;
+    @Mock private TeamMemberRepository teamMemberRepository;
+    @Mock private TeamAssetRepository teamAssetRepository;
+    @Mock private TeamInvitationRepository teamInvitationRepository;
+    @Mock private RoomRepository roomRepository;
+    @Mock private MemberRepository memberRepository;
+
+    private static final Long OWNER_ID = 1L;
+    private static final Long TEAM_ID = 10L;
+    private static final Long NON_OWNER_ID = 2L;
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = mock(Team.class);
+        lenient().when(team.getId()).thenReturn(TEAM_ID);
+    }
+
+    @Nested
+    @DisplayName("deleteTeam")
+    class DeleteTeam {
+
+        @Test
+        @DisplayName("성공: OWNER가 팀 삭제 시 자식 엔티티 삭제 후 팀 삭제")
+        void deleteTeam_성공_OWNER가_팀삭제() {
+            // given
+            given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
+            given(teamMemberRepository.existsByTeamIdAndMemberIdAndStatusAndRoleIn(
+                    TEAM_ID, OWNER_ID, TeamMemberStatus.ACTIVE, List.of(TeamRole.OWNER)))
+                    .willReturn(true);
+
+            // when
+            teamService.deleteTeam(OWNER_ID, TEAM_ID);
+
+            // then - 삭제 순서 검증: Room → TeamAsset → TeamInvitation → TeamMember → Team
+            InOrder inOrder = inOrder(roomRepository, teamAssetRepository,
+                    teamInvitationRepository, teamMemberRepository, teamRepository);
+            inOrder.verify(roomRepository).deleteAllByTeamId(TEAM_ID);
+            inOrder.verify(teamAssetRepository).deleteAllByTeamId(TEAM_ID);
+            inOrder.verify(teamInvitationRepository).deleteAllByTeamId(TEAM_ID);
+            inOrder.verify(teamMemberRepository).deleteAllByTeamId(TEAM_ID);
+            inOrder.verify(teamRepository).delete(team);
+        }
+
+        @Test
+        @DisplayName("실패: OWNER가 아닌 멤버가 팀 삭제 시도 시 TeamException 발생")
+        void deleteTeam_실패_OWNER가_아닌_경우() {
+            // given
+            given(teamRepository.findById(TEAM_ID)).willReturn(Optional.of(team));
+            given(teamMemberRepository.existsByTeamIdAndMemberIdAndStatusAndRoleIn(
+                    TEAM_ID, NON_OWNER_ID, TeamMemberStatus.ACTIVE, List.of(TeamRole.OWNER)))
+                    .willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> teamService.deleteTeam(NON_OWNER_ID, TEAM_ID))
+                    .isInstanceOf(TeamException.class);
+
+            // 삭제 로직이 실행되지 않음을 검증
+            verify(roomRepository, never()).deleteAllByTeamId(anyLong());
+            verify(teamMemberRepository, never()).deleteAllByTeamId(anyLong());
+            verify(teamRepository, never()).delete(any(Team.class));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 팀 삭제 시도 시 TeamException 발생")
+        void deleteTeam_실패_팀이_존재하지_않는_경우() {
+            // given
+            given(teamRepository.findById(TEAM_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> teamService.deleteTeam(OWNER_ID, TEAM_ID))
+                    .isInstanceOf(TeamException.class);
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,36 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+      - org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+
+jwt:
+  secret: dGVzdC1zZWNyZXQta2V5LWZvci11bml0LXRlc3RpbmctcHVycG9zZXMtb25seS0xMjM0NTY3ODkw
+  access-expiration: 1800000
+  refresh-expiration: 604800000
+
+cloud:
+  r2:
+    credentials:
+      access-key: test-key
+      secret-key: test-secret
+    endpoint: https://test.r2.cloudflarestorage.com
+    bucket: test-bucket
+    region: "auto"


### PR DESCRIPTION
#35 

### 문제
팀 삭제 API 호출 시 @Transactional 안에서, Hibernate가 영속성 컨텍스트(1차 캐시) 에 Team, TeamAsset, TeamMember를 managed 상태로 올려두고 변경 사항을 모아뒀다가 flush 시점에 SQL로 반영한다.
여기서 아직 DB에 반영되지 않은(또는 flush 중인) Dirty 엔티티가, 삭제 예정(Removed) 상태의 엔티티를 참조한 채로 flush가 발생하여 TransientObjectException가 발생

### 해결
Team 엔티티를 soft delete하는 방법도 있지만 데이터 복구를 하지 않을 것이므로, Team 엔티티를 참조하는 모든 엔티티 room, teamAsset, teamInvitation, teamMember을 hard delete후 team 엔티티 삭제