### PR TITLE
Feat/drawing beta stability

### DIFF
--- a/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/controller/DrawingSnapshotController.java
@@ -3,21 +3,9 @@ package com.writingboard.server.domain.drawing.controller;
 import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
 import com.writingboard.server.domain.drawing.dto.request.DrawingSnapshotRequest;
 import com.writingboard.server.domain.drawing.dto.response.DrawingSnapshotResponse;
-import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
-import com.writingboard.server.domain.drawing.enums.DrawingMessageType;
 import com.writingboard.server.domain.drawing.exception.DrawingErrorCode;
 import com.writingboard.server.domain.drawing.exception.DrawingException;
-import com.writingboard.server.domain.drawing.service.DrawingRedisPublisher;
 import com.writingboard.server.domain.drawing.service.DrawingSnapshotService;
-import com.writingboard.server.domain.meeting.entity.Room;
-import com.writingboard.server.domain.meeting.entity.RoomParticipant;
-import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
-import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
-import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
-import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
-import com.writingboard.server.domain.meeting.repository.RoomRepository;
-import com.writingboard.server.domain.member.entity.Member;
-import com.writingboard.server.domain.member.repository.MemberRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,10 +22,6 @@ import org.springframework.web.bind.annotation.*;
 public class DrawingSnapshotController {
 
     private final DrawingSnapshotService snapshotService;
-    private final RoomRepository roomRepository;
-    private final RoomParticipantRepository participantRepository;
-    private final MemberRepository memberRepository;
-    private final DrawingRedisPublisher drawingRedisPublisher;
 
     /**
      * 스냅샷 생성 (HOST만 가능)
@@ -52,25 +36,6 @@ public class DrawingSnapshotController {
         log.debug("스냅샷 생성 요청: roomUuid={}, roomAssetId={}, memberId={}, pageIndex={}, version={}",
                 roomUuid, roomAssetId, memberId, request.getPageIndex(), request.getLastIncludedVersion());
 
-        Room room = roomRepository.findByRoomUuid(roomUuid)
-                .orElseThrow(() -> new DrawingException(DrawingErrorCode.ROOM_NOT_FOUND));
-
-        if (room.getStatus() != RoomStatus.OPEN) {
-            throw new DrawingException(DrawingErrorCode.ROOM_CLOSED);
-        }
-
-        RoomParticipant participant = participantRepository
-                .findByRoomIdAndMemberId(room.getId(), memberId)
-                .orElseThrow(() -> new DrawingException(DrawingErrorCode.NOT_PARTICIPANT));
-
-        if (participant.getState() != ParticipantState.JOINED) {
-            throw new DrawingException(DrawingErrorCode.NOT_PARTICIPANT);
-        }
-
-        if (participant.getRole() != ParticipantRole.HOST) {
-            throw new DrawingException(DrawingErrorCode.SNAPSHOT_PERMISSION_DENIED);
-        }
-
         DrawingSnapshot snapshot = snapshotService.saveSnapshot(
                 memberId,
                 roomUuid,
@@ -79,8 +44,6 @@ public class DrawingSnapshotController {
                 request.getLastIncludedVersion(),
                 request.getSnapshotData()
         );
-
-        broadcastSnapshotNotification(snapshot);
 
         DrawingSnapshotResponse response = DrawingSnapshotResponse.from(snapshot);
 
@@ -105,33 +68,4 @@ public class DrawingSnapshotController {
         return ResponseEntity.ok(DrawingSnapshotResponse.from(snapshot));
     }
 
-    /**
-     * 스냅샷 생성 알림 브로드캐스트
-     */
-    private void broadcastSnapshotNotification(DrawingSnapshot snapshot) {
-        try {
-            Member creator = memberRepository.findById(snapshot.getCreatedBy())
-                    .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
-
-            DrawingStrokeDto notificationDto = DrawingStrokeDto.of(
-                    snapshot.getRoomUuid(),
-                    snapshot.getRoomAssetId(),
-                    creator.getId(),
-                    creator.getName(),
-                    DrawingMessageType.SNAPSHOT,
-                    snapshot.getPageIndex(),
-                    null,
-                    null,
-                    snapshot.getVersion()
-            );
-
-            drawingRedisPublisher.publish(snapshot.getRoomUuid(), notificationDto);
-
-            log.debug("스냅샷 생성 알림 브로드캐스트: roomUuid={}, roomAssetId={}, version={}",
-                    snapshot.getRoomUuid(), snapshot.getRoomAssetId(), snapshot.getVersion());
-
-        } catch (Exception e) {
-            log.error("스냅샷 알림 브로드캐스트 실패", e);
-        }
-    }
 }

--- a/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/document/DrawingSnapshot.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 
 
 @Document(collection = "drawing_snapshots")
+@CompoundIndex(name = "uk_asset_page_single_snapshot", def = "{'roomAssetId': 1, 'pageIndex': 1}", unique = true)
 @CompoundIndex(name = "idx_asset_page_version", def = "{'roomAssetId': 1, 'pageIndex': 1, 'version': -1}")
 @CompoundIndex(name = "idx_room_page_version", def = "{'roomUuid': 1, 'pageIndex': 1, 'version': -1}")
 @Getter

--- a/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
@@ -8,6 +8,11 @@ import java.util.Optional;
 
 public interface DrawingSnapshotRepository extends MongoRepository<DrawingSnapshot, String> {
 
+    Optional<DrawingSnapshot> findByRoomAssetIdAndPageIndex(
+            Long roomAssetId,
+            Integer pageIndex
+    );
+
     Optional<DrawingSnapshot> findFirstByRoomAssetIdAndPageIndexOrderByVersionDesc(
             Long roomAssetId,
             Integer pageIndex

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingService.java
@@ -16,10 +16,12 @@ import com.writingboard.server.domain.member.entity.Member;
 import com.writingboard.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
 
 
@@ -38,6 +40,8 @@ public class DrawingService {
     private final MemberRepository memberRepository;
     private final DrawingRedisPublisher drawingRedisPublisher;
     private final RedisTemplate<String, DrawingStrokeDto> drawingRedisTemplate;
+    @Value("${drawing.redis.ttl-minutes:180}")
+    private long drawingRedisTtlMinutes;
 
     /**
      * 드로잉 스트로크 전송
@@ -168,6 +172,7 @@ public class DrawingService {
             if (version == null) {
                 throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
             }
+            touchTtl(versionKey);
 
             log.debug("버전 할당: roomUuid={}, roomAssetId={}, pageIndex={}, version={}",
                     roomUuid, roomAssetId, pageIndex, version);
@@ -187,10 +192,22 @@ public class DrawingService {
         try {
             String bufferKey = buildBufferKey(roomUuid, roomAssetId, pageIndex);
             drawingRedisTemplate.opsForList().rightPush(bufferKey, strokeDto);
+            touchTtl(bufferKey);
         } catch (Exception e) {
             log.error("Redis 버퍼링 실패: roomUuid={}, roomAssetId={}, pageIndex={}",
                     roomUuid, roomAssetId, pageIndex, e);
             throw new DrawingException(DrawingErrorCode.REDIS_OPERATION_FAILED);
+        }
+    }
+
+    private void touchTtl(String key) {
+        try {
+            Boolean expireSet = drawingRedisTemplate.expire(key, Duration.ofMinutes(drawingRedisTtlMinutes));
+            if (Boolean.FALSE.equals(expireSet)) {
+                log.warn("Drawing 키 TTL 설정 실패: key={}, ttlMinutes={}", key, drawingRedisTtlMinutes);
+            }
+        } catch (Exception e) {
+            log.warn("Drawing 키 TTL 설정 중 예외: key={}, ttlMinutes={}", key, drawingRedisTtlMinutes, e);
         }
     }
 

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -5,6 +5,13 @@ import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
 import com.writingboard.server.domain.drawing.exception.DrawingErrorCode;
 import com.writingboard.server.domain.drawing.exception.DrawingException;
 import com.writingboard.server.domain.drawing.repository.DrawingSnapshotRepository;
+import com.writingboard.server.domain.meeting.entity.Room;
+import com.writingboard.server.domain.meeting.entity.RoomParticipant;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantRole;
+import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
+import com.writingboard.server.domain.meeting.entity.enums.RoomStatus;
+import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
+import com.writingboard.server.domain.meeting.repository.RoomRepository;
 import com.writingboard.server.domain.member.entity.Member;
 import com.writingboard.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +38,8 @@ public class DrawingSnapshotService {
     private static final String BUFFER_KEY_PREFIX = "drawing:buffer:";
 
     private final DrawingSnapshotRepository snapshotRepository;
+    private final RoomRepository roomRepository;
+    private final RoomParticipantRepository participantRepository;
     private final MemberRepository memberRepository;
     private final RedisTemplate<String, DrawingStrokeDto> drawingRedisTemplate;
     private final MongoTemplate mongoTemplate;
@@ -41,6 +50,8 @@ public class DrawingSnapshotService {
     @Transactional
     public DrawingSnapshot saveSnapshot(Long memberId, String roomUuid, Long roomAssetId, Integer pageIndex,
                                         Long lastIncludedVersion, String snapshotData) {
+        validateSnapshotCreationPermission(memberId, roomUuid);
+
         Optional<DrawingSnapshot> latestSnapshot = getLatestSnapshot(roomAssetId, pageIndex);
 
         if (latestSnapshot.isPresent() && latestSnapshot.get().getVersion() >= lastIncludedVersion) {
@@ -142,6 +153,27 @@ public class DrawingSnapshotService {
             log.error("스냅샷 upsert 실패: roomUuid={}, roomAssetId={}, pageIndex={}, version={}",
                     roomUuid, roomAssetId, pageIndex, lastIncludedVersion, e);
             throw new DrawingException(DrawingErrorCode.SNAPSHOT_SAVE_FAILED);
+        }
+    }
+
+    private void validateSnapshotCreationPermission(Long memberId, String roomUuid) {
+        Room room = roomRepository.findByRoomUuid(roomUuid)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.ROOM_NOT_FOUND));
+
+        if (room.getStatus() != RoomStatus.OPEN) {
+            throw new DrawingException(DrawingErrorCode.ROOM_CLOSED);
+        }
+
+        RoomParticipant participant = participantRepository
+                .findByRoomIdAndMemberId(room.getId(), memberId)
+                .orElseThrow(() -> new DrawingException(DrawingErrorCode.NOT_PARTICIPANT));
+
+        if (participant.getState() != ParticipantState.JOINED) {
+            throw new DrawingException(DrawingErrorCode.NOT_PARTICIPANT);
+        }
+
+        if (participant.getRole() != ParticipantRole.HOST) {
+            throw new DrawingException(DrawingErrorCode.SNAPSHOT_PERMISSION_DENIED);
         }
     }
 }

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -9,10 +9,17 @@ import com.writingboard.server.domain.member.entity.Member;
 import com.writingboard.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.Optional;
 
 
@@ -26,6 +33,7 @@ public class DrawingSnapshotService {
     private final DrawingSnapshotRepository snapshotRepository;
     private final MemberRepository memberRepository;
     private final RedisTemplate<String, DrawingStrokeDto> drawingRedisTemplate;
+    private final MongoTemplate mongoTemplate;
 
     /**
      * 스냅샷 저장 및 Redis 버퍼 정리
@@ -33,8 +41,6 @@ public class DrawingSnapshotService {
     @Transactional
     public DrawingSnapshot saveSnapshot(Long memberId, String roomUuid, Long roomAssetId, Integer pageIndex,
                                         Long lastIncludedVersion, String snapshotData) {
-
-
         Optional<DrawingSnapshot> latestSnapshot = getLatestSnapshot(roomAssetId, pageIndex);
 
         if (latestSnapshot.isPresent() && latestSnapshot.get().getVersion() >= lastIncludedVersion) {
@@ -43,21 +49,26 @@ public class DrawingSnapshotService {
             return latestSnapshot.get();
         }
 
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new DrawingException(DrawingErrorCode.MEMBER_NOT_FOUND));
 
-        DrawingSnapshot snapshot = DrawingSnapshot.create(
-                roomUuid, roomAssetId, pageIndex, lastIncludedVersion, snapshotData,
-                member.getId(), member.getName()
+        DrawingSnapshot saved = upsertLatestSnapshot(
+                roomUuid,
+                roomAssetId,
+                pageIndex,
+                lastIncludedVersion,
+                snapshotData,
+                member
         );
 
-        DrawingSnapshot saved = snapshotRepository.save(snapshot);
+        if (saved.getVersion() < lastIncludedVersion) {
+            throw new DrawingException(DrawingErrorCode.SNAPSHOT_SAVE_FAILED);
+        }
 
         log.info("스냅샷 저장 완료: roomUuid={}, roomAssetId={}, pageIndex={}, version={}",
-                roomUuid, roomAssetId, pageIndex, lastIncludedVersion);
+                roomUuid, roomAssetId, pageIndex, saved.getVersion());
 
-        trimRedisBuffer(roomUuid, roomAssetId, pageIndex, lastIncludedVersion);
+        trimRedisBuffer(roomUuid, roomAssetId, pageIndex, saved.getVersion());
 
         return saved;
     }
@@ -86,5 +97,51 @@ public class DrawingSnapshotService {
 
     private String buildBufferKey(String roomUuid, Long roomAssetId, Integer pageIndex) {
         return BUFFER_KEY_PREFIX + "room:" + roomUuid + ":asset:" + roomAssetId + ":page:" + pageIndex;
+    }
+
+    private DrawingSnapshot upsertLatestSnapshot(String roomUuid, Long roomAssetId, Integer pageIndex,
+                                                 Long lastIncludedVersion, String snapshotData, Member member) {
+        Query query = Query.query(new Criteria().andOperator(
+                Criteria.where("roomAssetId").is(roomAssetId),
+                Criteria.where("pageIndex").is(pageIndex),
+                new Criteria().orOperator(
+                        Criteria.where("version").lt(lastIncludedVersion),
+                        Criteria.where("version").exists(false)
+                )
+        ));
+
+        Update update = new Update()
+                .set("roomUuid", roomUuid)
+                .set("roomAssetId", roomAssetId)
+                .set("pageIndex", pageIndex)
+                .set("version", lastIncludedVersion)
+                .set("snapshotData", snapshotData)
+                .set("createdBy", member.getId())
+                .set("createdByName", member.getName())
+                .set("createdAt", Instant.now());
+
+        FindAndModifyOptions options = FindAndModifyOptions.options()
+                .upsert(true)
+                .returnNew(true);
+
+        try {
+            DrawingSnapshot updated = mongoTemplate.findAndModify(query, update, options, DrawingSnapshot.class);
+            if (updated != null) {
+                return updated;
+            }
+            return getLatestSnapshot(roomAssetId, pageIndex)
+                    .orElseThrow(() -> new DrawingException(DrawingErrorCode.SNAPSHOT_SAVE_FAILED));
+        } catch (DuplicateKeyException e) {
+            log.info("스냅샷 upsert 경쟁 감지: roomAssetId={}, pageIndex={}, incomingVersion={}",
+                    roomAssetId, pageIndex, lastIncludedVersion);
+            return getLatestSnapshot(roomAssetId, pageIndex)
+                    .orElseThrow(() -> new DrawingException(DrawingErrorCode.SNAPSHOT_SAVE_FAILED));
+        } catch (DrawingException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("스냅샷 upsert 실패: roomUuid={}, roomAssetId={}, pageIndex={}, version={}",
+                    roomUuid, roomAssetId, pageIndex, lastIncludedVersion, e);
+            throw new DrawingException(DrawingErrorCode.SNAPSHOT_SAVE_FAILED);
+        }
     }
 }

--- a/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/service/DrawingSnapshotService.java
@@ -89,7 +89,7 @@ public class DrawingSnapshotService {
      */
     @Transactional(readOnly = true)
     public Optional<DrawingSnapshot> getLatestSnapshot(Long roomAssetId, Integer pageIndex) {
-        return snapshotRepository.findFirstByRoomAssetIdAndPageIndexOrderByVersionDesc(roomAssetId, pageIndex);
+        return snapshotRepository.findByRoomAssetIdAndPageIndex(roomAssetId, pageIndex);
     }
 
     /**


### PR DESCRIPTION
1. redis ttl 적용
- drawing:version:*, drawing:buffer:* 키에 대해서 180분 후 자동 정리되도록 함
방 삭제시 레디스 키까지 정리하면 좋긴할듯요 ttl로 사라지긴 할텐데

2. MongoDB snapshot 저장을 insert → upsert로 전환
(roomAssetId, pageIndex)당 스냅샷 최신 1건만 유지

3. 기존 snapshot controller가 repository 주입받던거 수정
(이건 왜 이렇게 해놨지...? 너무 당연한건데)