### PR TITLE
[FEAT] 팀 노트 PDF + 필기 데이터 조회 및 저장 API 추가

### DIFF
--- a/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
+++ b/src/main/java/com/writingboard/server/domain/drawing/repository/DrawingSnapshotRepository.java
@@ -3,6 +3,7 @@ package com.writingboard.server.domain.drawing.repository;
 import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -19,6 +20,8 @@ public interface DrawingSnapshotRepository extends MongoRepository<DrawingSnapsh
             Long version
     );
 
+
+    List<DrawingSnapshot> findByRoomAssetId(Long roomAssetId);
 
     @Deprecated
     Optional<DrawingSnapshot> findFirstByRoomUuidAndPageIndexOrderByVersionDesc(

--- a/src/main/java/com/writingboard/server/domain/meeting/repository/RoomAssetRepository.java
+++ b/src/main/java/com/writingboard/server/domain/meeting/repository/RoomAssetRepository.java
@@ -31,4 +31,6 @@ public interface RoomAssetRepository extends JpaRepository<RoomAsset, Long> {
 
     @Query("SELECT ra FROM RoomAsset ra WHERE ra.room.roomUuid = :roomUuid AND ra.isActive = true")
     Optional<RoomAsset> findActiveByRoomUuid(@Param("roomUuid") String roomUuid);
+
+    Optional<RoomAsset> findFirstByTeamAssetIdOrderByCreatedAtDesc(Long teamAssetId);
 }

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamAssetController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamAssetController.java
@@ -1,11 +1,14 @@
 package com.writingboard.server.domain.team.controller;
 
+import com.writingboard.server.domain.drawing.dto.response.DrawingSnapshotResponse;
 import com.writingboard.server.domain.team.dto.TeamAssetPreviewImageUpdateResponse;
 import com.writingboard.server.domain.team.dto.request.AssetCreateRequest;
 import com.writingboard.server.domain.team.dto.request.AssetNewVersionRequest;
 import com.writingboard.server.domain.team.dto.request.AssetUpdateRequest;
+import com.writingboard.server.domain.team.dto.request.TeamAssetDrawingUpdateRequest;
 import com.writingboard.server.domain.team.dto.response.AssetListResponse;
 import com.writingboard.server.domain.team.dto.response.AssetResponse;
+import com.writingboard.server.domain.team.dto.response.TeamAssetNoteDataResponse;
 import com.writingboard.server.domain.team.service.TeamAssetService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -105,6 +108,29 @@ public class TeamAssetController {
             @RequestBody @Valid AssetNewVersionRequest request) {
 
         AssetResponse response = teamAssetService.createNewVersion(memberId, teamId, assetId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/{assetId}/note-data")
+    @Operation(summary = "팀 노트 데이터 조회", description = "팀 노트의 PDF 다운로드 URL과 회의에서 작성한 페이지별 필기 데이터를 함께 반환한다.")
+    public ResponseEntity<TeamAssetNoteDataResponse> getNoteData(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long assetId) {
+
+        TeamAssetNoteDataResponse response = teamAssetService.getNoteData(memberId, teamId, assetId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{assetId}/drawing-data")
+    @Operation(summary = "팀 노트 필기 데이터 저장", description = "회의 종료 후 팀 노트의 특정 페이지 필기 데이터를 저장한다.")
+    public ResponseEntity<DrawingSnapshotResponse> saveDrawingData(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long assetId,
+            @RequestBody @Valid TeamAssetDrawingUpdateRequest request) {
+
+        DrawingSnapshotResponse response = teamAssetService.saveDrawingData(memberId, teamId, assetId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/TeamAssetDrawingUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/TeamAssetDrawingUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TeamAssetDrawingUpdateRequest {
+
+    @NotNull(message = "pageIndex는 필수입니다")
+    @Min(value = 0, message = "pageIndex는 0 이상이어야 합니다")
+    private Integer pageIndex;
+
+    @NotBlank(message = "snapshotData는 필수입니다")
+    private String snapshotData;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/TeamAssetNoteDataResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/TeamAssetNoteDataResponse.java
@@ -1,0 +1,48 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
+import com.writingboard.server.domain.team.entity.TeamAsset;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.List;
+
+@Getter
+@Builder
+public class TeamAssetNoteDataResponse {
+
+    private Long teamAssetId;
+    private String name;
+    private String pdfDownloadUrl;
+    private Integer totalPages;
+    private List<DrawingPageData> drawingData;
+
+    public static TeamAssetNoteDataResponse of(TeamAsset asset, String pdfDownloadUrl, List<DrawingPageData> drawingData) {
+        return TeamAssetNoteDataResponse.builder()
+                .teamAssetId(asset.getId())
+                .name(asset.getName())
+                .pdfDownloadUrl(pdfDownloadUrl)
+                .totalPages(asset.getTotalPages())
+                .drawingData(drawingData)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class DrawingPageData {
+        private Integer pageIndex;
+        private Long version;
+        private String snapshotData;
+        private Instant createdAt;
+
+        public static DrawingPageData from(DrawingSnapshot snapshot) {
+            return DrawingPageData.builder()
+                    .pageIndex(snapshot.getPageIndex())
+                    .version(snapshot.getVersion())
+                    .snapshotData(snapshot.getSnapshotData())
+                    .createdAt(snapshot.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
@@ -37,7 +37,8 @@ public enum TeamErrorCode {
     ASSET_MODIFY_FORBIDDEN(HttpStatus.FORBIDDEN, "TEAM_402", "자산을 수정/삭제할 권한이 없습니다"),
     ASSET_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "TEAM_403", "이미 삭제된 자산입니다"),
     INVALID_ASSET_TYPE(HttpStatus.BAD_REQUEST, "TEAM_404", "지원하지 않는 파일 타입입니다"),
-    PREVIEW_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEAM_405", "preview 이미지 업로드에 실패했습니다");
+    PREVIEW_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEAM_405", "preview 이미지 업로드에 실패했습니다"),
+    NO_MEETING_HISTORY(HttpStatus.NOT_FOUND, "TEAM_406", "해당 자산을 사용한 회의 이력이 없습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamAssetService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamAssetService.java
@@ -1,13 +1,20 @@
 package com.writingboard.server.domain.team.service;
 
+import com.writingboard.server.domain.drawing.document.DrawingSnapshot;
+import com.writingboard.server.domain.drawing.repository.DrawingSnapshotRepository;
 import com.writingboard.server.domain.member.entity.Member;
 import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.meeting.entity.RoomAsset;
+import com.writingboard.server.domain.meeting.repository.RoomAssetRepository;
 import com.writingboard.server.domain.team.dto.TeamAssetPreviewImageUpdateResponse;
 import com.writingboard.server.domain.team.dto.request.AssetCreateRequest;
 import com.writingboard.server.domain.team.dto.request.AssetNewVersionRequest;
 import com.writingboard.server.domain.team.dto.request.AssetUpdateRequest;
+import com.writingboard.server.domain.team.dto.request.TeamAssetDrawingUpdateRequest;
+import com.writingboard.server.domain.drawing.dto.response.DrawingSnapshotResponse;
 import com.writingboard.server.domain.team.dto.response.AssetListResponse;
 import com.writingboard.server.domain.team.dto.response.AssetResponse;
+import com.writingboard.server.domain.team.dto.response.TeamAssetNoteDataResponse;
 import com.writingboard.server.domain.team.entity.Team;
 import com.writingboard.server.domain.team.entity.TeamAsset;
 import com.writingboard.server.domain.team.entity.enums.AssetSourceType;
@@ -28,7 +35,11 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +51,8 @@ public class TeamAssetService {
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
     private final StorageService storageService;
+    private final RoomAssetRepository roomAssetRepository;
+    private final DrawingSnapshotRepository drawingSnapshotRepository;
 
     @Transactional
     public AssetResponse createAsset(Long memberId, Long teamId, AssetCreateRequest request) {
@@ -148,6 +161,63 @@ public class TeamAssetService {
 
         String previewUrl = storageService.generateDownloadUrl(previewStorageKey).downloadUrl();
         return TeamAssetPreviewImageUpdateResponse.of(assetId, previewUrl);
+    }
+
+    public TeamAssetNoteDataResponse getNoteData(Long memberId, Long teamId, Long assetId) {
+        validateTeamMember(teamId, memberId);
+
+        TeamAsset asset = getActiveAssetByTeam(assetId, teamId);
+
+        String pdfDownloadUrl = storageService.generateDownloadUrl(asset.getStorageKey()).downloadUrl();
+
+        Optional<RoomAsset> latestRoomAsset = roomAssetRepository.findFirstByTeamAssetIdOrderByCreatedAtDesc(assetId);
+
+        List<TeamAssetNoteDataResponse.DrawingPageData> drawingData = latestRoomAsset
+                .map(roomAsset -> {
+                    List<DrawingSnapshot> snapshots = drawingSnapshotRepository.findByRoomAssetId(roomAsset.getId());
+                    return snapshots.stream()
+                            .collect(Collectors.toMap(
+                                    DrawingSnapshot::getPageIndex,
+                                    s -> s,
+                                    (a, b) -> a.getVersion() >= b.getVersion() ? a : b
+                            ))
+                            .values().stream()
+                            .sorted(Comparator.comparingInt(DrawingSnapshot::getPageIndex))
+                            .map(TeamAssetNoteDataResponse.DrawingPageData::from)
+                            .toList();
+                })
+                .orElse(List.of());
+
+        return TeamAssetNoteDataResponse.of(asset, pdfDownloadUrl, drawingData);
+    }
+
+    @Transactional
+    public DrawingSnapshotResponse saveDrawingData(Long memberId, Long teamId, Long assetId,
+                                                   TeamAssetDrawingUpdateRequest request) {
+        validateTeamMember(teamId, memberId);
+        getActiveAssetByTeam(assetId, teamId);
+
+        RoomAsset roomAsset = roomAssetRepository.findFirstByTeamAssetIdOrderByCreatedAtDesc(assetId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.NO_MEETING_HISTORY));
+
+        Member member = getMemberById(memberId);
+
+        long nextVersion = drawingSnapshotRepository
+                .findFirstByRoomAssetIdAndPageIndexOrderByVersionDesc(roomAsset.getId(), request.getPageIndex())
+                .map(s -> s.getVersion() + 1)
+                .orElse(1L);
+
+        DrawingSnapshot snapshot = DrawingSnapshot.create(
+                roomAsset.getRoom().getRoomUuid(),
+                roomAsset.getId(),
+                request.getPageIndex(),
+                nextVersion,
+                request.getSnapshotData(),
+                member.getId(),
+                member.getName()
+        );
+
+        return DrawingSnapshotResponse.from(drawingSnapshotRepository.save(snapshot));
     }
 
     // Helper methods


### PR DESCRIPTION
## Summary                                                                                                                                                                    
                                                                                                                                                                                 
 - 회의 종료 후 팀 노트의 PDF 파일과 페이지별 PencilKit 필기 데이터를 함께 반환하는 조회 API 추가                                                                              
 - 회의 종료 후 iOS 클라이언트에서 팀 노트 필기를 수정하고 저장할 수 있는 저장 API 추가                                                                                        
                                                                                                                                                                               
 ## API 변경사항                                                                                                                                                               
                                                                                                                                                                               
 ### `GET /api/teams/{teamId}/assets/{assetId}/note-data`                                                                                                                      
 - TeamAsset의 PDF presigned 다운로드 URL 반환                                                                                                                                 
 - 해당 자산을 사용한 가장 최근 회의(`RoomAsset`)의 페이지별 최신 `DrawingSnapshot` 반환
 - 필기 데이터가 없는 페이지는 응답에서 제외 (클라이언트에서 빈 캔버스로 처리)

 ```json
 {
   "teamAssetId": 1,
   "name": "lecture.pdf",
   "pdfDownloadUrl": "https://...",
   "totalPages": 5,
   "drawingData": [
     { "pageIndex": 0, "version": 12, "snapshotData": "...", "createdAt": "..." }
   ]
 }
 ```

 ### `POST /api/teams/{teamId}/assets/{assetId}/drawing-data`
 - 회의 종료 후 팀 노트 특정 페이지의 필기 데이터를 저장
 - Room OPEN 상태와 무관하게 동작 (회의실 밖에서 편집 지원)
 - 서버에서 버전 자동 채번 (현재 최신 버전 + 1)
 - 해당 자산이 회의에서 한 번도 사용된 적 없으면 `TEAM_406` 에러 반환

 ```json
 // Request
 { "pageIndex": 0, "snapshotData": "..." }
 ```

 ## 변경 파일

 | 파일 | 내용 |
 |------|------|
 | `DrawingSnapshotRepository` | `findByRoomAssetId()` 추가 |
 | `RoomAssetRepository` | `findFirstByTeamAssetIdOrderByCreatedAtDesc()` 추가 |
 | `TeamAssetController` | 두 엔드포인트 추가 |
 | `TeamAssetService` | `getNoteData()`, `saveDrawingData()` 구현 |
 | `TeamAssetNoteDataResponse` | 신규 응답 DTO |
 | `TeamAssetDrawingUpdateRequest` | 신규 요청 DTO |
 | `TeamErrorCode` | `NO_MEETING_HISTORY(TEAM_406)` 추가 |

 ## iOS 연동 흐름

 ```
 1. GET /note-data → pdfDownloadUrl로 PDF 렌더링 + snapshotData를 PKDrawing으로 로드
 2. 사용자 필기 수정
 3. 페이지 이동 / 백그라운드 진입 시 POST /drawing-data { pageIndex, snapshotData }