### PR TITLE
[FEAT] 소셜 로그인 공통 인프라 구성

### DIFF
--- a/src/main/java/com/writingboard/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/writingboard/server/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.writingboard.server.domain.auth.controller;
 
 import com.writingboard.server.domain.auth.dto.request.GuestLoginRequest;
 import com.writingboard.server.domain.auth.dto.request.RefreshTokenRequest;
+import com.writingboard.server.domain.auth.dto.request.SocialLoginRequest;
 import com.writingboard.server.domain.auth.dto.response.TokenResponse;
 import com.writingboard.server.domain.auth.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +31,16 @@ public class AuthController {
     public ResponseEntity<TokenResponse> guestLogin(@RequestBody @Valid GuestLoginRequest request) {
         TokenResponse response = authService.guestLogin(request.getDeviceId(), request.getName());
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    /**
+     * 소셜 로그인 - idToken 검증 후 JWT 발급
+     */
+    @Operation(summary = "소셜 로그인", description = "iOS 앱에서 획득한 idToken을 검증하여 JWT 토큰 발급 (provider: GOOGLE, APPLE)")
+    @PostMapping("/social-login")
+    public ResponseEntity<TokenResponse> socialLogin(@RequestBody @Valid SocialLoginRequest request) {
+        TokenResponse response = authService.socialLogin(request.getProvider(), request.getIdToken());
+        return ResponseEntity.ok(response);
     }
 
     /**

--- a/src/main/java/com/writingboard/server/domain/auth/dto/internal/SocialUserInfo.java
+++ b/src/main/java/com/writingboard/server/domain/auth/dto/internal/SocialUserInfo.java
@@ -1,0 +1,13 @@
+package com.writingboard.server.domain.auth.dto.internal;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SocialUserInfo {
+
+    private final String socialId;  // provider의 sub (고유 식별자)
+    private final String email;     // nullable - Apple은 최초 로그인 이후 미제공
+    private final String name;      // nullable
+}

--- a/src/main/java/com/writingboard/server/domain/auth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/writingboard/server/domain/auth/dto/request/SocialLoginRequest.java
@@ -1,0 +1,16 @@
+package com.writingboard.server.domain.auth.dto.request;
+
+import com.writingboard.server.domain.member.entity.enums.AuthProvider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class SocialLoginRequest {
+
+    @NotNull(message = "provider는 필수입니다")
+    private AuthProvider provider;
+
+    @NotBlank(message = "idToken은 필수입니다")
+    private String idToken;
+}

--- a/src/main/java/com/writingboard/server/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/auth/exception/AuthErrorCode.java
@@ -10,7 +10,10 @@ public enum AuthErrorCode {
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "유효하지 않은 토큰입니다.");
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "유효하지 않은 토큰입니다."),
+    SOCIAL_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "AUTH_004", "소셜 로그인에 실패했습니다."),
+    INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_005", "유효하지 않은 ID 토큰입니다."),
+    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "AUTH_006", "지원하지 않는 로그인 방식입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/writingboard/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/writingboard/server/domain/auth/service/AuthService.java
@@ -1,15 +1,19 @@
 package com.writingboard.server.domain.auth.service;
 
+import com.writingboard.server.domain.auth.dto.internal.SocialUserInfo;
 import com.writingboard.server.domain.auth.dto.response.TokenResponse;
 import com.writingboard.server.domain.auth.exception.AuthErrorCode;
 import com.writingboard.server.domain.auth.exception.AuthException;
 import com.writingboard.server.domain.auth.jwt.JwtProvider;
 import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.entity.enums.AuthProvider;
 import com.writingboard.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -19,6 +23,7 @@ public class AuthService {
 
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
+    private final List<SocialTokenVerifier> socialTokenVerifiers;
 
     /**
      * 게스트 로그인 - deviceId로 회원 조회 또는 생성
@@ -27,7 +32,7 @@ public class AuthService {
     public TokenResponse guestLogin(String deviceId, String name) {
         log.info("Guest login attempt - deviceId: {}", deviceId);
 
-        Member member = memberRepository.findByProviderId(deviceId)
+        Member member = memberRepository.findByProviderIdAndProvider(deviceId, AuthProvider.GUEST)
                 .orElseGet(() -> {
                     log.info("Creating new guest member - deviceId: {}", deviceId);
                     Member newMember = Member.createGuest(deviceId, name);
@@ -35,6 +40,36 @@ public class AuthService {
                 });
 
         log.info("Guest login successful - memberId: {}, deviceId: {}", member.getId(), deviceId);
+
+        return generateTokenResponse(member);
+    }
+
+    /**
+     * 소셜 로그인 - idToken 검증 후 회원 조회 또는 생성
+     */
+    @Transactional
+    public TokenResponse socialLogin(AuthProvider provider, String idToken) {
+        log.info("Social login attempt - provider: {}", provider);
+
+        SocialTokenVerifier verifier = socialTokenVerifiers.stream()
+                .filter(v -> v.getProvider() == provider)
+                .findFirst()
+                .orElseThrow(() -> new AuthException(AuthErrorCode.UNSUPPORTED_PROVIDER));
+
+        SocialUserInfo userInfo = verifier.verify(idToken);
+
+        Member member = memberRepository.findByProviderIdAndProvider(userInfo.getSocialId(), provider)
+                .orElseGet(() -> {
+                    log.info("Creating new social member - provider: {}, socialId: {}", provider, userInfo.getSocialId());
+                    String email = userInfo.getEmail() != null
+                            ? userInfo.getEmail()
+                            : provider.name().toLowerCase() + "-" + userInfo.getSocialId() + "@temp.local";
+                    String name = userInfo.getName() != null ? userInfo.getName() : provider.name() + "-User";
+                    Member newMember = Member.create(email, name, userInfo.getSocialId(), null, provider);
+                    return memberRepository.save(newMember);
+                });
+
+        log.info("Social login successful - provider: {}, memberId: {}", provider, member.getId());
 
         return generateTokenResponse(member);
     }

--- a/src/main/java/com/writingboard/server/domain/auth/service/SocialTokenVerifier.java
+++ b/src/main/java/com/writingboard/server/domain/auth/service/SocialTokenVerifier.java
@@ -1,0 +1,20 @@
+package com.writingboard.server.domain.auth.service;
+
+import com.writingboard.server.domain.auth.dto.internal.SocialUserInfo;
+import com.writingboard.server.domain.member.entity.enums.AuthProvider;
+
+public interface SocialTokenVerifier {
+
+    /**
+     * idToken을 검증하고 소셜 유저 정보를 반환한다.
+     *
+     * @param idToken iOS 앱에서 전달받은 ID 토큰
+     * @return 검증된 소셜 유저 정보 (socialId, email, name)
+     */
+    SocialUserInfo verify(String idToken);
+
+    /**
+     * 이 구현체가 담당하는 AuthProvider를 반환한다.
+     */
+    AuthProvider getProvider();
+}

--- a/src/main/java/com/writingboard/server/domain/member/entity/Member.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.writingboard.server.domain.member.entity;
 
+import com.writingboard.server.domain.member.entity.enums.AuthProvider;
 import com.writingboard.server.domain.member.entity.enums.MemberStatus;
 import com.writingboard.server.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -33,6 +34,10 @@ public class Member extends BaseEntity {
     private String providerId; // Guest: deviceId, OAuth: provider user ID
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "provider", columnDefinition = "VARCHAR(20) NOT NULL DEFAULT 'GUEST'")
+    private AuthProvider provider;
+
+    @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
     private MemberStatus status = MemberStatus.ACTIVE;
 
@@ -44,20 +49,22 @@ public class Member extends BaseEntity {
         member.email = "guest-" + deviceId.substring(0, Math.min(10, deviceId.length())) + "@temp.local";
         member.name = name != null && !name.isBlank() ? name : "Guest-" + deviceId.substring(0, 6).toUpperCase();
         member.providerId = deviceId;
+        member.provider = AuthProvider.GUEST;
         member.profileImageUrl = null;
         member.status = MemberStatus.ACTIVE;
         return member;
     }
 
     /**
-     * OAuth 사용자 생성
+     * 소셜 로그인 사용자 생성
      */
-    public static Member create(String email, String name, String providerId, String profileImageUrl) {
+    public static Member create(String email, String name, String providerId, String profileImageUrl, AuthProvider provider) {
         Member member = new Member();
         member.email = email;
         member.name = name;
         member.providerId = providerId;
         member.profileImageUrl = profileImageUrl;
+        member.provider = provider;
         member.status = MemberStatus.ACTIVE;
         return member;
     }

--- a/src/main/java/com/writingboard/server/domain/member/entity/enums/AuthProvider.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/enums/AuthProvider.java
@@ -1,0 +1,7 @@
+package com.writingboard.server.domain.member.entity.enums;
+
+public enum AuthProvider {
+    GUEST,
+    GOOGLE,
+    APPLE
+}

--- a/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/writingboard/server/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.writingboard.server.domain.member.repository;
 
 import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.entity.enums.AuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,6 +9,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     Optional<Member> findByProviderId(String providerId);
+    Optional<Member> findByProviderIdAndProvider(String providerId, AuthProvider provider);
 
-    Optional<Member> findByName (String username);
+    Optional<Member> findByName(String username);
 }

--- a/src/main/java/com/writingboard/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/",
                                 "/api/auth/guest-login",
+                                "/api/auth/social-login",
                                 "/api/auth/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",


### PR DESCRIPTION
## 개요
iOS 앱에서 Google/Apple 소셜 로그인을 지원하기 위한 공통 인프라를 구성함.

## 변경 사항

### `Member` 엔티티 확장
- `AuthProvider` enum 추가 (`GUEST`, `GOOGLE`, `APPLE`)
- `provider` 컬럼 추가 — 기존 게스트 유저와의 호환을 위해 DB default `'GUEST'` 설정
- `createGuest()` 팩토리 메서드에 `provider = GUEST` 설정
- `create()` 팩토리 메서드에 `AuthProvider` 파라미터 추가

### `MemberRepository`
- `findByProviderIdAndProvider()` 메서드 추가
  - provider 간 `providerId` 충돌 방지를 위해 기존 `findByProviderId()` 대신 사용

### 에러 코드 추가 (`AuthErrorCode`)
| 코드 | HTTP | 메시지 |
|------|------|--------|
| `AUTH_004` | 400 | 소셜 로그인에 실패했습니다. |
| `AUTH_005` | 401 | 유효하지 않은 ID 토큰입니다. |
| `AUTH_006` | 400 | 지원하지 않는 로그인 방식입니다. |

### 소셜 로그인 인터페이스 및 API
- `SocialTokenVerifier` 인터페이스 추가 — Issue 2/3 구현체가 따를 계약
- `SocialUserInfo` 내부 DTO 추가 (`socialId`, `email`, `name`)
- `POST /api/auth/social-login` 엔드포인트 추가
- `SecurityConfig`에 해당 경로 `permitAll` 등록

### `AuthService`
- `socialLogin(AuthProvider, String idToken)` 메서드 추가
  - `List<SocialTokenVerifier>`를 주입받아 provider에 맞는 verifier를 탐색
  - verifier가 없으면 `UNSUPPORTED_PROVIDER` 예외 발생
- `guestLogin()`에서 `findByProviderIdAndProvider(deviceId, GUEST)` 사용하도록 교체