### PR TITLE
[Feat]APNs 연결 및 direct 초대 알림 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,12 @@ jobs:
             R2_BUCKET=${{ secrets.R2_BUCKET }}
             R2_ENDPOINT=${{ secrets.R2_ENDPOINT }}
             
+            # APNs
+            APNS_TEAM_ID=${{ secrets.APNS_TEAM_ID }}
+            APNS_KEY_ID=${{ secrets.APNS_KEY_ID }}
+            APNS_KEY_PATH=${{ secrets.APNS_KEY_PATH }}
+            APNS_TOPIC=${{ secrets.APNS_TOPIC }}
+            
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
             APPLE_CLIENT_ID=${{ secrets.APPLE_CLIENT_ID }}
             GRAFANA_PASSWORD=${{ secrets.GRAFANA_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 .env
 /data
 CLAUDE.md
+
+# APNs private keys
+*.p8

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation 'software.amazon.awssdk:s3:2.25.27'
     implementation 'software.amazon.awssdk:netty-nio-client:2.25.27'
 
+    // APNs Push Notification
+    implementation 'com.eatthepath:pushy:0.15.4'
+
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/writingboard/server/domain/member/controller/DeviceTokenController.java
+++ b/src/main/java/com/writingboard/server/domain/member/controller/DeviceTokenController.java
@@ -1,0 +1,28 @@
+package com.writingboard.server.domain.member.controller;
+
+import com.writingboard.server.domain.member.dto.request.DeviceTokenRegisterRequest;
+import com.writingboard.server.domain.member.dto.response.DeviceTokenResponse;
+import com.writingboard.server.domain.member.service.DeviceTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members/me/device-tokens")
+@RequiredArgsConstructor
+public class DeviceTokenController {
+
+    private final DeviceTokenService deviceTokenService;
+
+    /**
+     * 디바이스 토큰 등록
+     */
+    @PostMapping
+    public ResponseEntity<DeviceTokenResponse> registerDeviceToken(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid DeviceTokenRegisterRequest request) {
+        return ResponseEntity.ok(deviceTokenService.registerDeviceToken(memberId, request));
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/member/dto/request/DeviceTokenRegisterRequest.java
+++ b/src/main/java/com/writingboard/server/domain/member/dto/request/DeviceTokenRegisterRequest.java
@@ -1,0 +1,22 @@
+package com.writingboard.server.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeviceTokenRegisterRequest {
+
+    @NotBlank(message = "디바이스 토큰은 필수입니다")
+    @Pattern(regexp = "^[0-9a-fA-F]{64}$", message = "유효하지 않은 APNs 디바이스 토큰 형식입니다")
+    private String token;
+
+    @Size(max = 50, message = "디바이스 모델은 50자 이내여야 합니다")
+    private String deviceModel;
+
+    @Size(max = 20, message = "OS 버전은 20자 이내여야 합니다")
+    private String osVersion;
+}

--- a/src/main/java/com/writingboard/server/domain/member/dto/response/DeviceTokenResponse.java
+++ b/src/main/java/com/writingboard/server/domain/member/dto/response/DeviceTokenResponse.java
@@ -1,0 +1,30 @@
+package com.writingboard.server.domain.member.dto.response;
+
+import com.writingboard.server.domain.member.entity.DeviceToken;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class DeviceTokenResponse {
+
+    private Long deviceTokenId;
+    private String token;
+    private String deviceModel;
+    private String osVersion;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public static DeviceTokenResponse of(DeviceToken deviceToken) {
+        return DeviceTokenResponse.builder()
+                .deviceTokenId(deviceToken.getId())
+                .token(deviceToken.getToken())
+                .deviceModel(deviceToken.getDeviceModel())
+                .osVersion(deviceToken.getOsVersion())
+                .createdAt(deviceToken.getCreatedAt())
+                .updatedAt(deviceToken.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/member/entity/DeviceToken.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/DeviceToken.java
@@ -1,0 +1,94 @@
+package com.writingboard.server.domain.member.entity;
+
+import com.writingboard.server.domain.member.entity.enums.DeviceTokenStatus;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "device_token",
+        uniqueConstraints = @UniqueConstraint(name = "uk_device_token", columnNames = "token"))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeviceToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "device_token_id")
+    private Long id;
+
+    @Column(name = "token", length = 255, nullable = false)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private DeviceTokenStatus status = DeviceTokenStatus.ACTIVE;
+
+    @Column(name = "device_model", length = 50)
+    private String deviceModel;
+
+    @Column(name = "os_version", length = 20)
+    private String osVersion;
+
+    /**
+     * 새 디바이스 토큰 생성
+     */
+    public static DeviceToken create(String token, Member member, String deviceModel, String osVersion) {
+        DeviceToken deviceToken = new DeviceToken();
+        deviceToken.token = token;
+        deviceToken.member = member;
+        deviceToken.status = DeviceTokenStatus.ACTIVE;
+        deviceToken.deviceModel = deviceModel;
+        deviceToken.osVersion = osVersion;
+        return deviceToken;
+    }
+
+    /**
+     * 토큰 갱신
+     */
+    public void refresh(String deviceModel, String osVersion) {
+        if (this.status == DeviceTokenStatus.DELETED) {
+            this.status = DeviceTokenStatus.ACTIVE;
+        }
+        if (deviceModel != null && !deviceModel.isBlank()) {
+            this.deviceModel = deviceModel;
+        }
+        if (osVersion != null && !osVersion.isBlank()) {
+            this.osVersion = osVersion;
+        }
+    }
+
+    /**
+     * 토큰 재할당 (다른 회원에게 토큰 소유권 이전)
+     */
+    public void reassignTo(Member member, String deviceModel, String osVersion) {
+        this.member = member;
+        this.status = DeviceTokenStatus.ACTIVE;
+        if (deviceModel != null && !deviceModel.isBlank()) {
+            this.deviceModel = deviceModel;
+        }
+        if (osVersion != null && !osVersion.isBlank()) {
+            this.osVersion = osVersion;
+        }
+    }
+
+    public void delete() {
+        this.status = DeviceTokenStatus.DELETED;
+    }
+
+
+    public boolean isDeleted() {
+        return this.status == DeviceTokenStatus.DELETED;
+    }
+
+
+    public boolean isActive() {
+        return this.status == DeviceTokenStatus.ACTIVE;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/member/entity/enums/DeviceTokenStatus.java
+++ b/src/main/java/com/writingboard/server/domain/member/entity/enums/DeviceTokenStatus.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.member.entity.enums;
+
+public enum DeviceTokenStatus {
+    ACTIVE,
+    DELETED
+}

--- a/src/main/java/com/writingboard/server/domain/member/exception/ErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/member/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     USER_ID_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "USER_ID_INVALID_FORMAT", "사용자 ID는 영문, 숫자, 밑줄(_)만 허용하며 3~20자여야 합니다."),
     NICKNAME_INVALID(HttpStatus.BAD_REQUEST, "NICKNAME_INVALID", "닉네임은 30자 이내여야 합니다."),
 
+    // DeviceToken 관련 (DEVICE_TOKEN_XXX)
+    DEVICE_TOKEN_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "DEVICE_TOKEN_001", "유효하지 않은 디바이스 토큰 형식입니다. APNs 토큰은 64자리 16진수여야 합니다."),
+
     // Auth 관련 (AUTH_XXX) 일단 여기 나중에 옮길거
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 만료되었습니다.");

--- a/src/main/java/com/writingboard/server/domain/member/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/writingboard/server/domain/member/repository/DeviceTokenRepository.java
@@ -1,0 +1,18 @@
+package com.writingboard.server.domain.member.repository;
+
+import com.writingboard.server.domain.member.entity.DeviceToken;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.entity.enums.DeviceTokenStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    Optional<DeviceToken> findByToken(String token);
+
+    List<DeviceToken> findByMemberAndStatus(Member member, DeviceTokenStatus status);
+
+    boolean existsByToken(String token);
+}

--- a/src/main/java/com/writingboard/server/domain/member/service/DeviceTokenService.java
+++ b/src/main/java/com/writingboard/server/domain/member/service/DeviceTokenService.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class DeviceTokenService {
 
-    // APNs device token: 64 hexadecimal characters
     private static final Pattern DEVICE_TOKEN_PATTERN = Pattern.compile("^[0-9a-fA-F]{64}$");
 
     private final DeviceTokenRepository deviceTokenRepository;
@@ -39,7 +38,7 @@ public class DeviceTokenService {
 
         validateTokenFormat(request.getToken());
 
-        // 기존 토큰 조회
+
         DeviceToken deviceToken = deviceTokenRepository.findByToken(request.getToken())
                 .map(existingToken -> {
                     // 다른 회원의 토큰이면 재할당

--- a/src/main/java/com/writingboard/server/domain/member/service/DeviceTokenService.java
+++ b/src/main/java/com/writingboard/server/domain/member/service/DeviceTokenService.java
@@ -1,0 +1,96 @@
+package com.writingboard.server.domain.member.service;
+
+import com.writingboard.server.domain.member.dto.request.DeviceTokenRegisterRequest;
+import com.writingboard.server.domain.member.dto.response.DeviceTokenResponse;
+import com.writingboard.server.domain.member.entity.DeviceToken;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.entity.enums.DeviceTokenStatus;
+import com.writingboard.server.domain.member.exception.ErrorCode;
+import com.writingboard.server.domain.member.exception.MemberException;
+import com.writingboard.server.domain.member.repository.DeviceTokenRepository;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeviceTokenService {
+
+    // APNs device token: 64 hexadecimal characters
+    private static final Pattern DEVICE_TOKEN_PATTERN = Pattern.compile("^[0-9a-fA-F]{64}$");
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 디바이스 토큰 등록 (Upsert)
+     * - 토큰이 이미 존재하면 갱신 (다른 회원의 토큰이면 재할당)
+     * - 토큰이 존재하지 않으면 신규 생성
+     */
+    @Transactional
+    public DeviceTokenResponse registerDeviceToken(Long memberId, DeviceTokenRegisterRequest request) {
+        Member member = getMemberById(memberId);
+
+        validateTokenFormat(request.getToken());
+
+        // 기존 토큰 조회
+        DeviceToken deviceToken = deviceTokenRepository.findByToken(request.getToken())
+                .map(existingToken -> {
+                    // 다른 회원의 토큰이면 재할당
+                    if (!existingToken.getMember().getId().equals(memberId)) {
+                        existingToken.reassignTo(member, request.getDeviceModel(), request.getOsVersion());
+                        return existingToken;
+                    }
+                    // 같은 회원의 토큰이면 갱신
+                    existingToken.refresh(request.getDeviceModel(), request.getOsVersion());
+                    return existingToken;
+                })
+                .orElseGet(() -> DeviceToken.create(
+                        request.getToken(),
+                        member,
+                        request.getDeviceModel(),
+                        request.getOsVersion()
+                ));
+
+        DeviceToken saved = deviceTokenRepository.save(deviceToken);
+        return DeviceTokenResponse.of(saved);
+    }
+
+    /**
+     * 특정 회원의 활성 토큰 조회 (푸시 발송용 - 내부 서비스 호출)
+     */
+    public List<String> getActiveTokensByMemberId(Long memberId) {
+        Member member = getMemberById(memberId);
+
+        return deviceTokenRepository.findByMemberAndStatus(member, DeviceTokenStatus.ACTIVE)
+                .stream()
+                .map(DeviceToken::getToken)
+                .collect(Collectors.toList());
+    }
+
+    private void validateTokenFormat(String token) {
+        if (token == null || token.isBlank()) {
+            throw new MemberException(ErrorCode.DEVICE_TOKEN_INVALID_FORMAT, "token");
+        }
+
+        if (!DEVICE_TOKEN_PATTERN.matcher(token).matches()) {
+            throw new MemberException(ErrorCode.DEVICE_TOKEN_INVALID_FORMAT, "token");
+        }
+    }
+
+    private Member getMemberById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.isDeleted()) {
+            throw new MemberException(ErrorCode.ALREADY_DELETED);
+        }
+        return member;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamInvitationService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamInvitationService.java
@@ -17,7 +17,9 @@ import com.writingboard.server.domain.team.exception.TeamException;
 import com.writingboard.server.domain.team.repository.TeamInvitationRepository;
 import com.writingboard.server.domain.team.repository.TeamMemberRepository;
 import com.writingboard.server.domain.team.repository.TeamRepository;
+import com.writingboard.server.global.notification.ApnsPushNotificationService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -37,6 +40,7 @@ public class TeamInvitationService {
     private final TeamMemberRepository teamMemberRepository;
     private final TeamInvitationRepository teamInvitationRepository;
     private final MemberRepository memberRepository;
+    private final ApnsPushNotificationService pushNotificationService;
 
     @Transactional
     public TeamInviteLinkResponse createLinkInvitation(Long memberId, Long teamId, TeamInviteLinkRequest request) {
@@ -86,6 +90,9 @@ public class TeamInvitationService {
 
         TeamInvitation invitation = TeamInvitation.createDirectInvitation(team, inviter, invitee);
         teamInvitationRepository.save(invitation);
+
+        // 푸시 알림 전송 (실패해도 초대 생성은 성공)
+        sendInvitationPushNotification(invitee, inviter, team);
 
         return TeamInvitationResponse.of(invitation);
     }
@@ -190,6 +197,30 @@ public class TeamInvitationService {
         return invitations.stream()
                 .map(TeamInvitationResponse::of)
                 .toList();
+    }
+
+    // Helper method for push notification
+    private void sendInvitationPushNotification(Member invitee, Member inviter, Team team) {
+        try {
+            String inviterName = inviter.getDisplayName();
+            String teamName = team.getName();
+
+            String title = "팀 초대";
+            String body = String.format("%s님이 %s 팀에 초대했습니다.",
+                inviterName != null ? inviterName : "Unknown",
+                teamName != null ? teamName : "Unknown"
+            );
+
+            log.info("Sending team invitation push notification - invitee: {}, team: {}",
+                invitee.getId(), team.getId());
+
+            pushNotificationService.sendToMember(invitee.getId(), title, body);
+
+        } catch (Exception e) {
+            // 로그만 남김
+            log.warn("Failed to send team invitation push notification - invitee: {}, team: {}",
+                invitee.getId(), team.getId(), e);
+        }
     }
 
     // Helper methods

--- a/src/main/java/com/writingboard/server/global/notification/ApnsConfig.java
+++ b/src/main/java/com/writingboard/server/global/notification/ApnsConfig.java
@@ -1,0 +1,46 @@
+package com.writingboard.server.global.notification;
+
+import com.eatthepath.pushy.apns.ApnsClient;
+import com.eatthepath.pushy.apns.ApnsClientBuilder;
+import com.eatthepath.pushy.apns.auth.ApnsSigningKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+@Slf4j
+@Configuration
+@EnableConfigurationProperties(ApnsProperties.class)
+@RequiredArgsConstructor
+public class ApnsConfig {
+
+    private final ApnsProperties apnsProperties;
+
+    @Bean
+    public ApnsClient apnsClient() throws IOException, InvalidKeyException, NoSuchAlgorithmException {
+        ApnsSigningKey signingKey = ApnsSigningKey.loadFromPkcs8File(
+            new File(apnsProperties.getKeyPath()),
+            apnsProperties.getTeamId(),
+            apnsProperties.getKeyId()
+        );
+
+        ApnsClient client = new ApnsClientBuilder()
+            .setApnsServer(apnsProperties.isProduction()
+                ? ApnsClientBuilder.PRODUCTION_APNS_HOST
+                : ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
+            .setSigningKey(signingKey)
+            .build();
+
+        log.info("APNs client initialized - environment: {}, topic: {}",
+            apnsProperties.isProduction() ? "PRODUCTION" : "DEVELOPMENT",
+            apnsProperties.getTopic());
+
+        return client;
+    }
+}

--- a/src/main/java/com/writingboard/server/global/notification/ApnsProperties.java
+++ b/src/main/java/com/writingboard/server/global/notification/ApnsProperties.java
@@ -1,0 +1,16 @@
+package com.writingboard.server.global.notification;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "apns")
+public class ApnsProperties {
+    private String teamId;
+    private String keyId;
+    private String keyPath;  // File path to .p8 key
+    private String topic;    // Bundle ID
+    private boolean production = false;
+}

--- a/src/main/java/com/writingboard/server/global/notification/ApnsPushNotificationService.java
+++ b/src/main/java/com/writingboard/server/global/notification/ApnsPushNotificationService.java
@@ -1,0 +1,79 @@
+package com.writingboard.server.global.notification;
+
+import com.eatthepath.pushy.apns.ApnsClient;
+import com.eatthepath.pushy.apns.PushNotificationResponse;
+import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
+import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
+import com.eatthepath.pushy.apns.util.concurrent.PushNotificationFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApnsPushNotificationService {
+
+    private final ApnsClient apnsClient;
+    private final ApnsProperties apnsProperties;
+
+    /**
+     * 동기 방식 푸시 알림 전송 (테스트용)
+     */
+    public void sendNotificationSync(String deviceToken, String title, String body) {
+        log.info("Sending push notification to token: {}", maskToken(deviceToken));
+
+        String payload = buildAlertPayload(title, body);
+        SimpleApnsPushNotification notification = new SimpleApnsPushNotification(
+            deviceToken,
+            apnsProperties.getTopic(),
+            payload
+        );
+
+        PushNotificationFuture<SimpleApnsPushNotification, PushNotificationResponse<SimpleApnsPushNotification>>
+            future = apnsClient.sendNotification(notification);
+
+        try {
+            PushNotificationResponse<SimpleApnsPushNotification> response = future.get();
+
+            if (response.isAccepted()) {
+                log.info("Push notification accepted by APNs - token: {}", maskToken(deviceToken));
+            } else {
+                String rejectionReason = response.getRejectionReason().orElse("Unknown");
+                Instant invalidationTime = response.getTokenInvalidationTimestamp().orElse(null);
+
+                log.error("Push notification rejected by APNs - token: {}, reason: {}, invalidationTime: {}",
+                    maskToken(deviceToken), rejectionReason, invalidationTime);
+
+                // TODO: Mark token as inactive in DeviceTokenService if rejection reason is Unregistered/BadDeviceToken
+
+                throw new RuntimeException("APNs rejected notification: " + rejectionReason);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Push notification interrupted - token: {}", maskToken(deviceToken), e);
+            throw new RuntimeException("Push notification interrupted", e);
+        } catch (ExecutionException e) {
+            log.error("Push notification execution failed - token: {}", maskToken(deviceToken), e);
+            throw new RuntimeException("Push notification execution failed", e);
+        }
+    }
+
+    private String buildAlertPayload(String title, String body) {
+        SimpleApnsPayloadBuilder payloadBuilder = new SimpleApnsPayloadBuilder();
+        payloadBuilder.setAlertTitle(title);
+        payloadBuilder.setAlertBody(body);
+        payloadBuilder.setSound("default");
+        return payloadBuilder.build();
+    }
+
+    private String maskToken(String token) {
+        if (token == null || token.length() < 12) {
+            return "***";
+        }
+        return token.substring(0, 8) + "..." + token.substring(token.length() - 4);
+    }
+}

--- a/src/main/java/com/writingboard/server/global/notification/ApnsPushNotificationService.java
+++ b/src/main/java/com/writingboard/server/global/notification/ApnsPushNotificationService.java
@@ -5,11 +5,13 @@ import com.eatthepath.pushy.apns.PushNotificationResponse;
 import com.eatthepath.pushy.apns.util.SimpleApnsPayloadBuilder;
 import com.eatthepath.pushy.apns.util.SimpleApnsPushNotification;
 import com.eatthepath.pushy.apns.util.concurrent.PushNotificationFuture;
+import com.writingboard.server.domain.member.service.DeviceTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 @Slf4j
@@ -19,6 +21,32 @@ public class ApnsPushNotificationService {
 
     private final ApnsClient apnsClient;
     private final ApnsProperties apnsProperties;
+    private final DeviceTokenService deviceTokenService;
+
+    /**
+     * 특정 회원에게 푸시 알림 전송
+     * - 회원의 모든 활성 디바이스 토큰으로 전송
+     * - 개별 토큰 전송 실패는 로그만 남기고 계속 진행
+     */
+    public void sendToMember(Long memberId, String title, String body) {
+        List<String> activeTokens = deviceTokenService.getActiveTokensByMemberId(memberId);
+
+        if (activeTokens.isEmpty()) {
+            log.info("No active device tokens for member: {}", memberId);
+            return;
+        }
+
+        log.info("Sending push notification to member: {} ({} tokens)", memberId, activeTokens.size());
+
+        for (String token : activeTokens) {
+            try {
+                sendNotificationSync(token, title, body);
+            } catch (Exception e) {
+                log.error("Failed to send push notification to token: {} - member: {}",
+                    maskToken(token), memberId, e);
+            }
+        }
+    }
 
     /**
      * 동기 방식 푸시 알림 전송 (테스트용)

--- a/src/main/java/com/writingboard/server/global/notification/PushNotificationTestController.java
+++ b/src/main/java/com/writingboard/server/global/notification/PushNotificationTestController.java
@@ -1,0 +1,46 @@
+package com.writingboard.server.global.notification;
+
+import com.writingboard.server.global.notification.dto.PushNotificationTestRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/push")
+@RequiredArgsConstructor
+@Tag(name = "Push Notification (Dev Only)", description = "개발 환경 전용 푸시 알림 테스트 API")
+@Profile("dev")  // DEV 환경에서만 활성화
+public class PushNotificationTestController {
+
+    private final ApnsPushNotificationService pushNotificationService;
+
+    @PostMapping("/test")
+    @Operation(
+        summary = "푸시 알림 테스트 전송",
+        description = "APNs로 테스트 푸시 알림을 전송합니다. (개발 환경 전용)"
+    )
+    public ResponseEntity<String> sendTestNotification(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid PushNotificationTestRequest request) {
+
+        log.info("Member {} requested test push notification", memberId);
+
+        pushNotificationService.sendNotificationSync(
+            request.deviceToken(),
+            request.title(),
+            request.body()
+        );
+
+        return ResponseEntity.ok("푸시 알림이 성공적으로 전송되었습니다");
+    }
+}

--- a/src/main/java/com/writingboard/server/global/notification/dto/PushNotificationTestRequest.java
+++ b/src/main/java/com/writingboard/server/global/notification/dto/PushNotificationTestRequest.java
@@ -1,0 +1,20 @@
+package com.writingboard.server.global.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record PushNotificationTestRequest(
+    @NotBlank(message = "디바이스 토큰은 필수입니다")
+    @Pattern(regexp = "^[0-9a-fA-F]{64}$", message = "유효하지 않은 APNs 토큰 형식입니다")
+    String deviceToken,
+
+    @NotBlank(message = "알림 제목을 입력해주세요")
+    @Size(max = 100, message = "알림 제목은 100자 이내여야 합니다")
+    String title,
+
+    @NotBlank(message = "알림 내용을 입력해주세요")
+    @Size(max = 500, message = "알림 내용은 500자 이내여야 합니다")
+    String body
+) {
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -64,3 +64,10 @@ cloud:
     endpoint: ${R2_ENDPOINT}
     bucket: ${R2_BUCKET}
     region: "auto"
+
+apns:
+  team-id: ${APNS_TEAM_ID:YOUR_TEAM_ID}
+  key-id: ${APNS_KEY_ID:YOUR_KEY_ID}
+  key-path: ${APNS_KEY_PATH:/path/to/AuthKey.p8}
+  topic: ${APNS_TOPIC:com.writingboard.app}
+  production: false

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -74,3 +74,10 @@ cloud:
     endpoint: ${R2_ENDPOINT}
     bucket: ${R2_BUCKET}
     region: "auto"
+
+apns:
+  team-id: ${APNS_TEAM_ID}
+  key-id: ${APNS_KEY_ID}
+  key-path: ${APNS_KEY_PATH}
+  topic: ${APNS_TOPIC}
+  production: true

--- a/src/test/java/com/writingboard/server/domain/member/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/writingboard/server/domain/member/service/DeviceTokenServiceTest.java
@@ -1,0 +1,369 @@
+package com.writingboard.server.domain.member.service;
+
+import com.writingboard.server.domain.member.dto.request.DeviceTokenRegisterRequest;
+import com.writingboard.server.domain.member.dto.response.DeviceTokenResponse;
+import com.writingboard.server.domain.member.entity.DeviceToken;
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.entity.enums.DeviceTokenStatus;
+import com.writingboard.server.domain.member.entity.enums.MemberStatus;
+import com.writingboard.server.domain.member.exception.ErrorCode;
+import com.writingboard.server.domain.member.exception.MemberException;
+import com.writingboard.server.domain.member.repository.DeviceTokenRepository;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeviceTokenService 단위 테스트")
+class DeviceTokenServiceTest {
+
+    @InjectMocks
+    private DeviceTokenService deviceTokenService;
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private static final Long MEMBER_ID_1 = 1L;
+    private static final Long MEMBER_ID_2 = 2L;
+    private static final String VALID_TOKEN = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+    private static final String ANOTHER_VALID_TOKEN = "fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321";
+    private static final String INVALID_TOKEN = "invalid";
+    private static final String DEVICE_MODEL = "iPhone 15 Pro";
+    private static final String OS_VERSION = "iOS 17.2";
+    private static final String UPDATED_DEVICE_MODEL = "iPhone 15 Pro Max";
+    private static final String UPDATED_OS_VERSION = "iOS 17.3";
+
+    private Member member1;
+    private Member member2;
+    private DeviceTokenRegisterRequest request;
+
+    @BeforeEach
+    void setUp() {
+        member1 = mock(Member.class);
+        member2 = mock(Member.class);
+        lenient().when(member1.getId()).thenReturn(MEMBER_ID_1);
+        lenient().when(member2.getId()).thenReturn(MEMBER_ID_2);
+        lenient().when(member1.isDeleted()).thenReturn(false);
+        lenient().when(member2.isDeleted()).thenReturn(false);
+
+        request = new DeviceTokenRegisterRequest();
+    }
+
+    @Nested
+    @DisplayName("registerDeviceToken")
+    class RegisterDeviceToken {
+
+        @Test
+        @DisplayName("성공: 새 토큰 등록")
+        void registerDeviceToken_성공_새토큰등록() {
+            // given
+            setRequestFields(VALID_TOKEN, DEVICE_MODEL, OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+            given(deviceTokenRepository.findByToken(VALID_TOKEN)).willReturn(Optional.empty());
+
+            DeviceToken newToken = DeviceToken.create(VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+            given(deviceTokenRepository.save(any(DeviceToken.class))).willReturn(newToken);
+
+            // when
+            DeviceTokenResponse response = deviceTokenService.registerDeviceToken(MEMBER_ID_1, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getToken()).isEqualTo(VALID_TOKEN);
+            assertThat(response.getDeviceModel()).isEqualTo(DEVICE_MODEL);
+            assertThat(response.getOsVersion()).isEqualTo(OS_VERSION);
+            verify(deviceTokenRepository).save(any(DeviceToken.class));
+        }
+
+        @Test
+        @DisplayName("성공: 같은 member + 같은 token 재등록 시 메타데이터 갱신")
+        void registerDeviceToken_성공_같은멤버_같은토큰_재등록() {
+            // given
+            setRequestFields(VALID_TOKEN, UPDATED_DEVICE_MODEL, UPDATED_OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            DeviceToken existingToken = DeviceToken.create(VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+            given(deviceTokenRepository.findByToken(VALID_TOKEN)).willReturn(Optional.of(existingToken));
+            given(deviceTokenRepository.save(existingToken)).willReturn(existingToken);
+
+            // when
+            DeviceTokenResponse response = deviceTokenService.registerDeviceToken(MEMBER_ID_1, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(existingToken.getDeviceModel()).isEqualTo(UPDATED_DEVICE_MODEL);
+            assertThat(existingToken.getOsVersion()).isEqualTo(UPDATED_OS_VERSION);
+            assertThat(existingToken.isActive()).isTrue();
+            verify(deviceTokenRepository).save(existingToken);
+        }
+
+        @Test
+        @DisplayName("성공: 같은 member + 다른 token 등록 시 새 토큰 생성")
+        void registerDeviceToken_성공_같은멤버_다른토큰() {
+            // given
+            setRequestFields(ANOTHER_VALID_TOKEN, DEVICE_MODEL, OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+            given(deviceTokenRepository.findByToken(ANOTHER_VALID_TOKEN)).willReturn(Optional.empty());
+
+            DeviceToken newToken = DeviceToken.create(ANOTHER_VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+            given(deviceTokenRepository.save(any(DeviceToken.class))).willReturn(newToken);
+
+            // when
+            DeviceTokenResponse response = deviceTokenService.registerDeviceToken(MEMBER_ID_1, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getToken()).isEqualTo(ANOTHER_VALID_TOKEN);
+            verify(deviceTokenRepository).save(any(DeviceToken.class));
+        }
+
+        @Test
+        @DisplayName("성공: 다른 member + 같은 token 등록 시 기존 row 재할당")
+        void registerDeviceToken_성공_다른멤버_같은토큰_재할당() {
+            // given
+            setRequestFields(VALID_TOKEN, UPDATED_DEVICE_MODEL, UPDATED_OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_2)).willReturn(Optional.of(member2));
+
+            DeviceToken existingToken = DeviceToken.create(VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+            given(deviceTokenRepository.findByToken(VALID_TOKEN)).willReturn(Optional.of(existingToken));
+            given(deviceTokenRepository.save(existingToken)).willReturn(existingToken);
+
+            // when
+            DeviceTokenResponse response = deviceTokenService.registerDeviceToken(MEMBER_ID_2, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(existingToken.getMember()).isEqualTo(member2);
+            assertThat(existingToken.getDeviceModel()).isEqualTo(UPDATED_DEVICE_MODEL);
+            assertThat(existingToken.getOsVersion()).isEqualTo(UPDATED_OS_VERSION);
+            assertThat(existingToken.isActive()).isTrue();
+            verify(deviceTokenRepository).save(existingToken);
+            verify(deviceTokenRepository, never()).flush();
+        }
+
+        @Test
+        @DisplayName("성공: DELETED 토큰 재등록 시 ACTIVE 복구")
+        void registerDeviceToken_성공_DELETED토큰_재등록() {
+            // given
+            setRequestFields(VALID_TOKEN, UPDATED_DEVICE_MODEL, UPDATED_OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            DeviceToken deletedToken = DeviceToken.create(VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+            deletedToken.delete();
+            given(deviceTokenRepository.findByToken(VALID_TOKEN)).willReturn(Optional.of(deletedToken));
+            given(deviceTokenRepository.save(deletedToken)).willReturn(deletedToken);
+
+            // when
+            DeviceTokenResponse response = deviceTokenService.registerDeviceToken(MEMBER_ID_1, request);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(deletedToken.isActive()).isTrue();
+            assertThat(deletedToken.isDeleted()).isFalse();
+            assertThat(deletedToken.getDeviceModel()).isEqualTo(UPDATED_DEVICE_MODEL);
+            assertThat(deletedToken.getOsVersion()).isEqualTo(UPDATED_OS_VERSION);
+            verify(deviceTokenRepository).save(deletedToken);
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 토큰 형식")
+        void registerDeviceToken_실패_유효하지않은토큰형식() {
+            // given
+            setRequestFields(INVALID_TOKEN, DEVICE_MODEL, OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            // when & then
+            assertThatThrownBy(() -> deviceTokenService.registerDeviceToken(MEMBER_ID_1, request))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DEVICE_TOKEN_INVALID_FORMAT);
+
+            verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+        }
+
+        @Test
+        @DisplayName("실패: null 토큰")
+        void registerDeviceToken_실패_null토큰() {
+            // given
+            setRequestFields(null, DEVICE_MODEL, OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            // when & then
+            assertThatThrownBy(() -> deviceTokenService.registerDeviceToken(MEMBER_ID_1, request))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DEVICE_TOKEN_INVALID_FORMAT);
+
+            verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+        }
+
+        @Test
+        @DisplayName("실패: 빈 문자열 토큰")
+        void registerDeviceToken_실패_빈문자열토큰() {
+            // given
+            setRequestFields("", DEVICE_MODEL, OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            // when & then
+            assertThatThrownBy(() -> deviceTokenService.registerDeviceToken(MEMBER_ID_1, request))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.DEVICE_TOKEN_INVALID_FORMAT);
+
+            verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+        }
+
+        @Test
+        @DisplayName("실패: Member가 존재하지 않음")
+        void registerDeviceToken_실패_Member없음() {
+            // given
+            setRequestFields(VALID_TOKEN, DEVICE_MODEL, OS_VERSION);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> deviceTokenService.registerDeviceToken(MEMBER_ID_1, request))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+
+            verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+        }
+
+        @Test
+        @DisplayName("실패: 이미 탈퇴한 Member")
+        void registerDeviceToken_실패_탈퇴한Member() {
+            // given
+            setRequestFields(VALID_TOKEN, DEVICE_MODEL, OS_VERSION);
+            when(member1.isDeleted()).thenReturn(true);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            // when & then
+            assertThatThrownBy(() -> deviceTokenService.registerDeviceToken(MEMBER_ID_1, request))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_DELETED);
+
+            verify(deviceTokenRepository, never()).save(any(DeviceToken.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getActiveTokensByMemberId")
+    class GetActiveTokensByMemberId {
+
+        @Test
+        @DisplayName("성공: ACTIVE 토큰만 조회")
+        void getActiveTokensByMemberId_성공_ACTIVE토큰만조회() {
+            // given
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            DeviceToken activeToken1 = DeviceToken.create(VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+            DeviceToken activeToken2 = DeviceToken.create(ANOTHER_VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+
+            given(deviceTokenRepository.findByMemberAndStatus(member1, DeviceTokenStatus.ACTIVE))
+                    .willReturn(List.of(activeToken1, activeToken2));
+
+            // when
+            List<String> tokens = deviceTokenService.getActiveTokensByMemberId(MEMBER_ID_1);
+
+            // then
+            assertThat(tokens).hasSize(2);
+            assertThat(tokens).contains(VALID_TOKEN, ANOTHER_VALID_TOKEN);
+        }
+
+        @Test
+        @DisplayName("성공: DELETED 토큰은 조회되지 않음")
+        void getActiveTokensByMemberId_성공_DELETED토큰제외() {
+            // given
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            DeviceToken activeToken = DeviceToken.create(VALID_TOKEN, member1, DEVICE_MODEL, OS_VERSION);
+
+            given(deviceTokenRepository.findByMemberAndStatus(member1, DeviceTokenStatus.ACTIVE))
+                    .willReturn(List.of(activeToken));
+
+            // when
+            List<String> tokens = deviceTokenService.getActiveTokensByMemberId(MEMBER_ID_1);
+
+            // then
+            assertThat(tokens).hasSize(1);
+            assertThat(tokens).contains(VALID_TOKEN);
+            assertThat(tokens).doesNotContain(ANOTHER_VALID_TOKEN);
+        }
+
+        @Test
+        @DisplayName("성공: 활성 토큰이 없으면 빈 리스트 반환")
+        void getActiveTokensByMemberId_성공_빈리스트() {
+            // given
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+            given(deviceTokenRepository.findByMemberAndStatus(member1, DeviceTokenStatus.ACTIVE))
+                    .willReturn(List.of());
+
+            // when
+            List<String> tokens = deviceTokenService.getActiveTokensByMemberId(MEMBER_ID_1);
+
+            // then
+            assertThat(tokens).isEmpty();
+        }
+
+        @Test
+        @DisplayName("실패: Member가 존재하지 않음")
+        void getActiveTokensByMemberId_실패_Member없음() {
+            // given
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> deviceTokenService.getActiveTokensByMemberId(MEMBER_ID_1))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MEMBER_NOT_FOUND);
+
+            verify(deviceTokenRepository, never()).findByMemberAndStatus(any(), any());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 탈퇴한 Member")
+        void getActiveTokensByMemberId_실패_탈퇴한Member() {
+            // given
+            when(member1.isDeleted()).thenReturn(true);
+            given(memberRepository.findById(MEMBER_ID_1)).willReturn(Optional.of(member1));
+
+            // when & then
+            assertThatThrownBy(() -> deviceTokenService.getActiveTokensByMemberId(MEMBER_ID_1))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALREADY_DELETED);
+
+            verify(deviceTokenRepository, never()).findByMemberAndStatus(any(), any());
+        }
+    }
+
+    private void setRequestFields(String token, String deviceModel, String osVersion) {
+        try {
+            var tokenField = DeviceTokenRegisterRequest.class.getDeclaredField("token");
+            tokenField.setAccessible(true);
+            tokenField.set(request, token);
+
+            var deviceModelField = DeviceTokenRegisterRequest.class.getDeclaredField("deviceModel");
+            deviceModelField.setAccessible(true);
+            deviceModelField.set(request, deviceModel);
+
+            var osVersionField = DeviceTokenRegisterRequest.class.getDeclaredField("osVersion");
+            osVersionField.setAccessible(true);
+            osVersionField.set(request, osVersion);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
- DeviceToken 관리 기능 추가
- Pushy 기반 APNs 연결 추가
- direct invitation 생성 시 푸시 알림 전송 연동
- 푸시 실패 시에도 초대 생성은 정상 처리




- 현재 푸시 전송은 동기 호출 방식이라 APNs 호출 latency만큼 응답이 다소 느려질 수 있음
- 프론트 실기기 연동 확인 후 비동기/이벤트 기반으로 분리 예정