### PR TITLE
팀별 채팅, 개인 프로필 설정, 회의 일정 캘린더 기능 추가

### DIFF
--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamMemberController.java
@@ -1,14 +1,18 @@
 package com.writingboard.server.domain.team.controller;
 
 import com.writingboard.server.domain.team.dto.request.RoleChangeRequest;
+import com.writingboard.server.domain.team.dto.request.TeamProfileUpdateRequest;
 import com.writingboard.server.domain.team.dto.response.TeamMemberResponse;
+import com.writingboard.server.domain.team.dto.response.TeamProfileResponse;
 import com.writingboard.server.domain.team.service.TeamMemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -60,5 +64,44 @@ public class TeamMemberController {
 
         TeamMemberResponse updatedMember = teamMemberService.changeRole(memberId, teamId, targetMemberId, request);
         return ResponseEntity.ok(updatedMember);
+    }
+
+    @GetMapping("/me/profile")
+    @Operation(summary = "내 팀 프로필 조회", description = "현재 인증된 사용자의 팀별 프로필을 조회한다.")
+    public ResponseEntity<TeamProfileResponse> getMyProfile(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId) {
+
+        return ResponseEntity.ok(teamMemberService.getMyProfile(memberId, teamId));
+    }
+
+    @PutMapping("/me/profile")
+    @Operation(summary = "팀 프로필 닉네임 수정", description = "팀별 닉네임을 수정한다.")
+    public ResponseEntity<TeamProfileResponse> updateMyProfile(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestBody @Valid TeamProfileUpdateRequest request) {
+
+        return ResponseEntity.ok(teamMemberService.updateMyNickname(memberId, teamId, request));
+    }
+
+    @PutMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "팀 프로필 이미지 업로드", description = "팀별 프로필 이미지를 업로드한다.")
+    public ResponseEntity<TeamProfileResponse> updateMyProfileImage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestPart("profileImage") MultipartFile profileImage) {
+
+        return ResponseEntity.ok(teamMemberService.updateMyProfileImage(memberId, teamId, profileImage));
+    }
+
+    @GetMapping("/{targetMemberId}/profile")
+    @Operation(summary = "특정 멤버의 팀 프로필 조회", description = "특정 멤버의 팀별 프로필을 조회한다.")
+    public ResponseEntity<TeamProfileResponse> getMemberProfile(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long targetMemberId) {
+
+        return ResponseEntity.ok(teamMemberService.getMemberProfile(memberId, teamId, targetMemberId));
     }
 }

--- a/src/main/java/com/writingboard/server/domain/team/controller/TeamScheduleController.java
+++ b/src/main/java/com/writingboard/server/domain/team/controller/TeamScheduleController.java
@@ -1,0 +1,70 @@
+package com.writingboard.server.domain.team.controller;
+
+import com.writingboard.server.domain.team.dto.request.ScheduleCreateRequest;
+import com.writingboard.server.domain.team.dto.request.ScheduleUpdateRequest;
+import com.writingboard.server.domain.team.dto.response.ScheduleResponse;
+import com.writingboard.server.domain.team.service.TeamScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/teams/{teamId}/schedules")
+@RequiredArgsConstructor
+@Tag(name = "Team Schedule", description = "팀 일정 API")
+public class TeamScheduleController {
+
+    private final TeamScheduleService teamScheduleService;
+
+    @GetMapping
+    @Operation(summary = "기간별 일정 목록 조회")
+    public ResponseEntity<List<ScheduleResponse>> getSchedules(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestParam OffsetDateTime from,
+            @RequestParam OffsetDateTime to) {
+
+        return ResponseEntity.ok(teamScheduleService.getSchedules(memberId, teamId, from, to));
+    }
+
+    @PostMapping
+    @Operation(summary = "일정 생성")
+    public ResponseEntity<ScheduleResponse> createSchedule(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestBody @Valid ScheduleCreateRequest request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(teamScheduleService.createSchedule(memberId, teamId, request));
+    }
+
+    @PutMapping("/{scheduleId}")
+    @Operation(summary = "일정 수정")
+    public ResponseEntity<ScheduleResponse> updateSchedule(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long scheduleId,
+            @RequestBody @Valid ScheduleUpdateRequest request) {
+
+        return ResponseEntity.ok(teamScheduleService.updateSchedule(memberId, teamId, scheduleId, request));
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    @Operation(summary = "일정 삭제")
+    public ResponseEntity<Void> deleteSchedule(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable Long scheduleId) {
+
+        teamScheduleService.deleteSchedule(memberId, teamId, scheduleId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/RecurrenceRuleRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/RecurrenceRuleRequest.java
@@ -1,0 +1,28 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import com.writingboard.server.domain.team.entity.enums.RecurrenceFrequency;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecurrenceRuleRequest {
+
+    @NotNull(message = "반복 주기는 필수입니다")
+    private RecurrenceFrequency frequency;
+
+    @Min(value = 1, message = "반복 간격은 1 이상이어야 합니다")
+    private Integer interval;
+
+    private List<DayOfWeek> daysOfWeek;
+
+    private LocalDate endDate;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/ScheduleCreateRequest.java
@@ -1,0 +1,35 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleCreateRequest {
+
+    @NotBlank(message = "일정 제목은 필수입니다")
+    @Size(max = 200, message = "일정 제목은 최대 200자까지 가능합니다")
+    private String title;
+
+    @Size(max = 1000, message = "일정 설명은 최대 1000자까지 가능합니다")
+    private String description;
+
+    @NotNull(message = "시작 시간은 필수입니다")
+    private OffsetDateTime startTime;
+
+    @NotNull(message = "종료 시간은 필수입니다")
+    private OffsetDateTime endTime;
+
+    @Valid
+    private RecurrenceRuleRequest recurrenceRule;
+
+    private Integer reminderMinutesBefore;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/ScheduleUpdateRequest.java
@@ -1,0 +1,35 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleUpdateRequest {
+
+    @NotBlank(message = "일정 제목은 필수입니다")
+    @Size(max = 200, message = "일정 제목은 최대 200자까지 가능합니다")
+    private String title;
+
+    @Size(max = 1000, message = "일정 설명은 최대 1000자까지 가능합니다")
+    private String description;
+
+    @NotNull(message = "시작 시간은 필수입니다")
+    private OffsetDateTime startTime;
+
+    @NotNull(message = "종료 시간은 필수입니다")
+    private OffsetDateTime endTime;
+
+    @Valid
+    private RecurrenceRuleRequest recurrenceRule;
+
+    private Integer reminderMinutesBefore;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/request/TeamProfileUpdateRequest.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/request/TeamProfileUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.writingboard.server.domain.team.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamProfileUpdateRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(max = 30, message = "닉네임은 최대 30자까지 가능합니다")
+    private String nickname;
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/RecurrenceRuleResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/RecurrenceRuleResponse.java
@@ -1,0 +1,32 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.RecurrenceRule;
+import com.writingboard.server.domain.team.entity.enums.RecurrenceFrequency;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@Builder
+public class RecurrenceRuleResponse {
+
+    private RecurrenceFrequency frequency;
+    private Integer interval;
+    private List<DayOfWeek> daysOfWeek;
+    private LocalDate endDate;
+
+    public static RecurrenceRuleResponse of(RecurrenceRule rule) {
+        if (rule == null || rule.getFrequency() == null) {
+            return null;
+        }
+        return RecurrenceRuleResponse.builder()
+                .frequency(rule.getFrequency())
+                .interval(rule.getInterval())
+                .daysOfWeek(rule.getDaysOfWeek())
+                .endDate(rule.getEndDate())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/ScheduleResponse.java
@@ -1,0 +1,49 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.TeamSchedule;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+
+@Data
+@Builder
+public class ScheduleResponse {
+
+    private Long scheduleId;
+    private Long teamId;
+    private String title;
+    private String description;
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
+    private RecurrenceRuleResponse recurrenceRule;
+    private Integer reminderMinutesBefore;
+    private CreatedByInfo createdBy;
+    private Instant createdAt;
+
+    @Data
+    @Builder
+    public static class CreatedByInfo {
+        private Long memberId;
+        private String name;
+    }
+
+    public static ScheduleResponse of(TeamSchedule schedule) {
+        return ScheduleResponse.builder()
+                .scheduleId(schedule.getId())
+                .teamId(schedule.getTeam().getId())
+                .title(schedule.getTitle())
+                .description(schedule.getDescription())
+                .startTime(schedule.getStartTime())
+                .endTime(schedule.getEndTime())
+                .recurrenceRule(RecurrenceRuleResponse.of(schedule.getRecurrenceRule()))
+                .reminderMinutesBefore(schedule.getReminderMinutesBefore())
+                .createdBy(CreatedByInfo.builder()
+                        .memberId(schedule.getCreatedBy().getId())
+                        .name(schedule.getCreatedBy().getDisplayName())
+                        .build())
+                .createdAt(schedule.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/dto/response/TeamProfileResponse.java
+++ b/src/main/java/com/writingboard/server/domain/team/dto/response/TeamProfileResponse.java
@@ -1,0 +1,26 @@
+package com.writingboard.server.domain.team.dto.response;
+
+import com.writingboard.server.domain.team.entity.TeamMember;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TeamProfileResponse {
+
+    private Long memberId;
+    private Long teamId;
+    private String nickname;
+    private String profileImageUrl;
+    private String globalName;
+
+    public static TeamProfileResponse of(TeamMember teamMember, String profileImageUrl) {
+        return TeamProfileResponse.builder()
+                .memberId(teamMember.getMember().getId())
+                .teamId(teamMember.getTeam().getId())
+                .nickname(teamMember.getNickname())
+                .profileImageUrl(profileImageUrl)
+                .globalName(teamMember.getMember().getDisplayName())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/RecurrenceRule.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/RecurrenceRule.java
@@ -1,0 +1,56 @@
+package com.writingboard.server.domain.team.entity;
+
+import com.writingboard.server.domain.team.entity.enums.RecurrenceFrequency;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecurrenceRule {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recurrence_frequency", length = 20)
+    private RecurrenceFrequency frequency;
+
+    @Column(name = "recurrence_interval")
+    private Integer interval;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "schedule_days_of_week",
+            joinColumns = @JoinColumn(name = "schedule_id"),
+            foreignKey = @ForeignKey(name = "fk_schedule_days_schedule")
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", length = 10)
+    private List<DayOfWeek> daysOfWeek = new ArrayList<>();
+
+    @Column(name = "recurrence_end_date")
+    private LocalDate endDate;
+
+    public static RecurrenceRule create(RecurrenceFrequency frequency, Integer interval,
+                                        List<DayOfWeek> daysOfWeek, LocalDate endDate) {
+        RecurrenceRule rule = new RecurrenceRule();
+        rule.frequency = frequency;
+        rule.interval = interval != null ? interval : 1;
+        rule.daysOfWeek = daysOfWeek != null ? new ArrayList<>(daysOfWeek) : new ArrayList<>();
+        rule.endDate = endDate;
+        return rule;
+    }
+
+    public void update(RecurrenceFrequency frequency, Integer interval,
+                       List<DayOfWeek> daysOfWeek, LocalDate endDate) {
+        this.frequency = frequency;
+        this.interval = interval != null ? interval : 1;
+        this.daysOfWeek = daysOfWeek != null ? new ArrayList<>(daysOfWeek) : new ArrayList<>();
+        this.endDate = endDate;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamMember.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamMember.java
@@ -42,6 +42,12 @@ public class TeamMember extends BaseEntity {
     @Column(name = "joined_at")
     private Instant joinedAt;
 
+    @Column(name = "nickname", length = 30)
+    private String nickname;
+
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
     public static TeamMember createOwner(Team team, Member member) {
         TeamMember tm = new TeamMember();
         tm.team = team;
@@ -103,5 +109,20 @@ public class TeamMember extends BaseEntity {
 
     public boolean isActive() {
         return this.status == TeamMemberStatus.ACTIVE;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public String getDisplayName() {
+        if (nickname != null && !nickname.isBlank()) {
+            return nickname;
+        }
+        return member.getDisplayName();
     }
 }

--- a/src/main/java/com/writingboard/server/domain/team/entity/TeamSchedule.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/TeamSchedule.java
@@ -1,0 +1,74 @@
+package com.writingboard.server.domain.team.entity;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "team_schedule")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamSchedule extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false, foreignKey = @ForeignKey(name = "fk_schedule_team"))
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "created_by", nullable = false, foreignKey = @ForeignKey(name = "fk_schedule_member"))
+    private Member createdBy;
+
+    @Column(name = "title", length = 200, nullable = false)
+    private String title;
+
+    @Column(name = "description", length = 1000)
+    private String description;
+
+    @Column(name = "start_time", nullable = false)
+    private OffsetDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private OffsetDateTime endTime;
+
+    @Embedded
+    private RecurrenceRule recurrenceRule;
+
+    @Column(name = "reminder_minutes_before")
+    private Integer reminderMinutesBefore;
+
+    public static TeamSchedule create(Team team, Member createdBy, String title, String description,
+                                       OffsetDateTime startTime, OffsetDateTime endTime,
+                                       RecurrenceRule recurrenceRule, Integer reminderMinutesBefore) {
+        TeamSchedule schedule = new TeamSchedule();
+        schedule.team = team;
+        schedule.createdBy = createdBy;
+        schedule.title = title;
+        schedule.description = description;
+        schedule.startTime = startTime;
+        schedule.endTime = endTime;
+        schedule.recurrenceRule = recurrenceRule;
+        schedule.reminderMinutesBefore = reminderMinutesBefore;
+        return schedule;
+    }
+
+    public void update(String title, String description,
+                       OffsetDateTime startTime, OffsetDateTime endTime,
+                       RecurrenceRule recurrenceRule, Integer reminderMinutesBefore) {
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.recurrenceRule = recurrenceRule;
+        this.reminderMinutesBefore = reminderMinutesBefore;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/team/entity/enums/RecurrenceFrequency.java
+++ b/src/main/java/com/writingboard/server/domain/team/entity/enums/RecurrenceFrequency.java
@@ -1,0 +1,7 @@
+package com.writingboard.server.domain.team.entity.enums;
+
+public enum RecurrenceFrequency {
+    DAILY,
+    WEEKLY,
+    MONTHLY
+}

--- a/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
@@ -41,7 +41,10 @@ public enum TeamErrorCode {
     NO_MEETING_HISTORY(HttpStatus.NOT_FOUND, "TEAM_406", "해당 자산을 사용한 회의 이력이 없습니다"),
 
     // Profile
-    PROFILE_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEAM_501", "프로필 이미지 업로드에 실패했습니다");
+    PROFILE_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEAM_501", "프로필 이미지 업로드에 실패했습니다"),
+
+    // Schedule
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_601", "일정을 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/team/exception/TeamErrorCode.java
@@ -38,7 +38,10 @@ public enum TeamErrorCode {
     ASSET_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "TEAM_403", "이미 삭제된 자산입니다"),
     INVALID_ASSET_TYPE(HttpStatus.BAD_REQUEST, "TEAM_404", "지원하지 않는 파일 타입입니다"),
     PREVIEW_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEAM_405", "preview 이미지 업로드에 실패했습니다"),
-    NO_MEETING_HISTORY(HttpStatus.NOT_FOUND, "TEAM_406", "해당 자산을 사용한 회의 이력이 없습니다");
+    NO_MEETING_HISTORY(HttpStatus.NOT_FOUND, "TEAM_406", "해당 자산을 사용한 회의 이력이 없습니다"),
+
+    // Profile
+    PROFILE_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "TEAM_501", "프로필 이미지 업로드에 실패했습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/writingboard/server/domain/team/repository/TeamScheduleRepository.java
+++ b/src/main/java/com/writingboard/server/domain/team/repository/TeamScheduleRepository.java
@@ -1,0 +1,34 @@
+package com.writingboard.server.domain.team.repository;
+
+import com.writingboard.server.domain.team.entity.TeamSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface TeamScheduleRepository extends JpaRepository<TeamSchedule, Long> {
+
+    Optional<TeamSchedule> findByIdAndTeamId(Long id, Long teamId);
+
+    @Query("""
+            SELECT s FROM TeamSchedule s
+            WHERE s.team.id = :teamId
+            AND (
+                (s.recurrenceRule.frequency IS NULL AND s.startTime >= :from AND s.startTime <= :to)
+                OR
+                (s.recurrenceRule.frequency IS NOT NULL AND s.startTime <= :to
+                    AND (s.recurrenceRule.endDate IS NULL OR s.recurrenceRule.endDate >= CAST(:fromDate AS LocalDate)))
+            )
+            ORDER BY s.startTime ASC
+            """)
+    List<TeamSchedule> findByTeamIdAndDateRange(
+            @Param("teamId") Long teamId,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to,
+            @Param("fromDate") OffsetDateTime fromDate);
+
+    void deleteAllByTeamId(Long teamId);
+}

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamMemberService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamMemberService.java
@@ -1,7 +1,9 @@
 package com.writingboard.server.domain.team.service;
 
 import com.writingboard.server.domain.team.dto.request.RoleChangeRequest;
+import com.writingboard.server.domain.team.dto.request.TeamProfileUpdateRequest;
 import com.writingboard.server.domain.team.dto.response.TeamMemberResponse;
+import com.writingboard.server.domain.team.dto.response.TeamProfileResponse;
 import com.writingboard.server.domain.team.entity.TeamMember;
 import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
 import com.writingboard.server.domain.team.entity.enums.TeamRole;
@@ -9,10 +11,13 @@ import com.writingboard.server.domain.team.exception.TeamErrorCode;
 import com.writingboard.server.domain.team.exception.TeamException;
 import com.writingboard.server.domain.team.repository.TeamMemberRepository;
 import com.writingboard.server.domain.team.repository.TeamRepository;
+import com.writingboard.server.global.storage.StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -22,6 +27,7 @@ public class TeamMemberService {
 
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final StorageService storageService;
 
     public List<TeamMemberResponse> getTeamMembers(Long teamId, Long memberId) {
         validateTeamExists(teamId);
@@ -95,6 +101,56 @@ public class TeamMemberService {
         }
 
         return TeamMemberResponse.of(targetMember);
+    }
+
+    public TeamProfileResponse getMyProfile(Long memberId, Long teamId) {
+        validateTeamExists(teamId);
+        TeamMember teamMember = getTeamMember(teamId, memberId);
+        String profileImageUrl = resolveProfileImageUrl(teamMember);
+        return TeamProfileResponse.of(teamMember, profileImageUrl);
+    }
+
+    public TeamProfileResponse getMemberProfile(Long memberId, Long teamId, Long targetMemberId) {
+        validateTeamExists(teamId);
+        validateTeamMember(teamId, memberId);
+        TeamMember teamMember = getTeamMember(teamId, targetMemberId);
+        String profileImageUrl = resolveProfileImageUrl(teamMember);
+        return TeamProfileResponse.of(teamMember, profileImageUrl);
+    }
+
+    @Transactional
+    public TeamProfileResponse updateMyNickname(Long memberId, Long teamId, TeamProfileUpdateRequest request) {
+        validateTeamExists(teamId);
+        TeamMember teamMember = getTeamMember(teamId, memberId);
+        teamMember.updateNickname(request.getNickname());
+        String profileImageUrl = resolveProfileImageUrl(teamMember);
+        return TeamProfileResponse.of(teamMember, profileImageUrl);
+    }
+
+    @Transactional
+    public TeamProfileResponse updateMyProfileImage(Long memberId, Long teamId, MultipartFile file) {
+        validateTeamExists(teamId);
+        TeamMember teamMember = getTeamMember(teamId, memberId);
+
+        String storageKey = "profiles/teams/" + teamId + "/members/" + memberId + ".jpg";
+
+        try {
+            storageService.uploadObject(storageKey, file.getInputStream(), file.getSize(), file.getContentType());
+        } catch (IOException e) {
+            throw new TeamException(TeamErrorCode.PROFILE_IMAGE_UPLOAD_FAILED);
+        }
+
+        teamMember.updateProfileImageUrl(storageKey);
+
+        String profileImageUrl = storageService.generateDownloadUrl(storageKey).downloadUrl();
+        return TeamProfileResponse.of(teamMember, profileImageUrl);
+    }
+
+    private String resolveProfileImageUrl(TeamMember teamMember) {
+        if (teamMember.getProfileImageUrl() != null && !teamMember.getProfileImageUrl().isBlank()) {
+            return storageService.generateDownloadUrl(teamMember.getProfileImageUrl()).downloadUrl();
+        }
+        return teamMember.getMember().getProfileImageUrl();
     }
 
     // Helper methods

--- a/src/main/java/com/writingboard/server/domain/team/service/TeamScheduleService.java
+++ b/src/main/java/com/writingboard/server/domain/team/service/TeamScheduleService.java
@@ -1,0 +1,124 @@
+package com.writingboard.server.domain.team.service;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.dto.request.RecurrenceRuleRequest;
+import com.writingboard.server.domain.team.dto.request.ScheduleCreateRequest;
+import com.writingboard.server.domain.team.dto.request.ScheduleUpdateRequest;
+import com.writingboard.server.domain.team.dto.response.ScheduleResponse;
+import com.writingboard.server.domain.team.entity.RecurrenceRule;
+import com.writingboard.server.domain.team.entity.Team;
+import com.writingboard.server.domain.team.entity.TeamSchedule;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.exception.TeamErrorCode;
+import com.writingboard.server.domain.team.exception.TeamException;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.team.repository.TeamRepository;
+import com.writingboard.server.domain.team.repository.TeamScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamScheduleService {
+
+    private final TeamScheduleRepository teamScheduleRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
+
+    public List<ScheduleResponse> getSchedules(Long memberId, Long teamId,
+                                                OffsetDateTime from, OffsetDateTime to) {
+        validateTeamMember(teamId, memberId);
+
+        List<TeamSchedule> schedules = teamScheduleRepository.findByTeamIdAndDateRange(
+                teamId, from, to, from);
+
+        return schedules.stream()
+                .map(ScheduleResponse::of)
+                .toList();
+    }
+
+    @Transactional
+    public ScheduleResponse createSchedule(Long memberId, Long teamId, ScheduleCreateRequest request) {
+        Team team = getTeamById(teamId);
+        validateTeamMember(teamId, memberId);
+        Member creator = getMemberById(memberId);
+
+        RecurrenceRule recurrenceRule = toRecurrenceRule(request.getRecurrenceRule());
+
+        TeamSchedule schedule = TeamSchedule.create(
+                team, creator,
+                request.getTitle(), request.getDescription(),
+                request.getStartTime(), request.getEndTime(),
+                recurrenceRule, request.getReminderMinutesBefore()
+        );
+
+        teamScheduleRepository.save(schedule);
+        return ScheduleResponse.of(schedule);
+    }
+
+    @Transactional
+    public ScheduleResponse updateSchedule(Long memberId, Long teamId, Long scheduleId,
+                                            ScheduleUpdateRequest request) {
+        validateTeamMember(teamId, memberId);
+
+        TeamSchedule schedule = teamScheduleRepository.findByIdAndTeamId(scheduleId, teamId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.SCHEDULE_NOT_FOUND));
+
+        RecurrenceRule recurrenceRule = toRecurrenceRule(request.getRecurrenceRule());
+
+        schedule.update(
+                request.getTitle(), request.getDescription(),
+                request.getStartTime(), request.getEndTime(),
+                recurrenceRule, request.getReminderMinutesBefore()
+        );
+
+        return ScheduleResponse.of(schedule);
+    }
+
+    @Transactional
+    public void deleteSchedule(Long memberId, Long teamId, Long scheduleId) {
+        validateTeamMember(teamId, memberId);
+
+        TeamSchedule schedule = teamScheduleRepository.findByIdAndTeamId(scheduleId, teamId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.SCHEDULE_NOT_FOUND));
+
+        teamScheduleRepository.delete(schedule);
+    }
+
+    private RecurrenceRule toRecurrenceRule(RecurrenceRuleRequest request) {
+        if (request == null) {
+            return null;
+        }
+        return RecurrenceRule.create(
+                request.getFrequency(),
+                request.getInterval(),
+                request.getDaysOfWeek(),
+                request.getEndDate()
+        );
+    }
+
+    private Team getTeamById(Long teamId) {
+        return teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.TEAM_NOT_FOUND));
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new TeamException(TeamErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private void validateTeamMember(Long teamId, Long memberId) {
+        boolean isMember = teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(
+                teamId, memberId, TeamMemberStatus.ACTIVE);
+        if (!isMember) {
+            throw new TeamException(TeamErrorCode.NOT_TEAM_MEMBER);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/controller/TeamChatController.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/controller/TeamChatController.java
@@ -1,0 +1,61 @@
+package com.writingboard.server.domain.teamchat.controller;
+
+import com.writingboard.server.domain.teamchat.dto.request.TeamChatMessageRequest;
+import com.writingboard.server.domain.teamchat.dto.response.TeamChatMessageResponse;
+import com.writingboard.server.domain.teamchat.service.TeamChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/teams/{teamId}/chat/messages")
+@RequiredArgsConstructor
+@Tag(name = "Team Chat", description = "팀 채팅 API")
+public class TeamChatController {
+
+    private final TeamChatService teamChatService;
+
+    @GetMapping
+    @Operation(summary = "팀 채팅 메시지 목록 조회")
+    public ResponseEntity<Page<TeamChatMessageResponse>> getMessages(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+
+        Pageable pageable = PageRequest.of(page, Math.min(size, 100),
+                Sort.by(Sort.Direction.DESC, "timestamp"));
+        return ResponseEntity.ok(teamChatService.getMessages(memberId, teamId, pageable));
+    }
+
+    @PostMapping
+    @Operation(summary = "팀 채팅 메시지 전송")
+    public ResponseEntity<TeamChatMessageResponse> sendMessage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @RequestBody @Valid TeamChatMessageRequest request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(teamChatService.sendMessage(memberId, teamId, request));
+    }
+
+    @DeleteMapping("/{messageId}")
+    @Operation(summary = "팀 채팅 메시지 삭제")
+    public ResponseEntity<Void> deleteMessage(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long teamId,
+            @PathVariable String messageId) {
+
+        teamChatService.deleteMessage(memberId, teamId, messageId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/document/TeamChatMessage.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/document/TeamChatMessage.java
@@ -1,0 +1,49 @@
+package com.writingboard.server.domain.teamchat.document;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.teamchat.enums.TeamChatMessageType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document(collection = "team_chat_messages")
+@CompoundIndex(name = "idx_team_timestamp", def = "{'teamId': 1, 'timestamp': -1}")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamChatMessage {
+
+    @Id
+    private String id;
+
+    private Long teamId;
+    private Long senderId;
+    private String senderName;
+    private String content;
+    private TeamChatMessageType type;
+    private Instant timestamp;
+
+    private TeamChatMessage(Long teamId, Long senderId, String senderName,
+                            String content, TeamChatMessageType type) {
+        this.teamId = teamId;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.content = content;
+        this.type = type;
+        this.timestamp = Instant.now();
+    }
+
+    public static TeamChatMessage createText(Long teamId, Member sender, String content) {
+        return new TeamChatMessage(
+                teamId,
+                sender.getId(),
+                sender.getDisplayName(),
+                content,
+                TeamChatMessageType.TEXT
+        );
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/dto/request/TeamChatMessageRequest.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/dto/request/TeamChatMessageRequest.java
@@ -1,0 +1,22 @@
+package com.writingboard.server.domain.teamchat.dto.request;
+
+import com.writingboard.server.domain.teamchat.enums.TeamChatMessageType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamChatMessageRequest {
+
+    @NotBlank(message = "메시지 내용은 필수입니다")
+    @Size(max = 2000, message = "메시지는 최대 2000자까지 가능합니다")
+    private String content;
+
+    @NotNull(message = "메시지 타입은 필수입니다")
+    private TeamChatMessageType type;
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/dto/response/TeamChatEventDto.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/dto/response/TeamChatEventDto.java
@@ -1,0 +1,20 @@
+package com.writingboard.server.domain.teamchat.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.writingboard.server.domain.teamchat.enums.TeamChatEventType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TeamChatEventDto {
+
+    private TeamChatEventType eventType;
+    private TeamChatMessageResponse message;
+    private String messageId;
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/dto/response/TeamChatMessageResponse.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/dto/response/TeamChatMessageResponse.java
@@ -1,0 +1,47 @@
+package com.writingboard.server.domain.teamchat.dto.response;
+
+import com.writingboard.server.domain.teamchat.document.TeamChatMessage;
+import com.writingboard.server.domain.teamchat.enums.TeamChatMessageType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+public class TeamChatMessageResponse {
+
+    private String messageId;
+    private Long teamId;
+    private Long senderId;
+    private String senderName;
+    private String content;
+    private TeamChatMessageType type;
+    private Instant createdAt;
+
+    @Builder
+    public TeamChatMessageResponse(String messageId, Long teamId, Long senderId,
+                                   String senderName, String content,
+                                   TeamChatMessageType type, Instant createdAt) {
+        this.messageId = messageId;
+        this.teamId = teamId;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.content = content;
+        this.type = type;
+        this.createdAt = createdAt;
+    }
+
+    public static TeamChatMessageResponse from(TeamChatMessage message) {
+        return TeamChatMessageResponse.builder()
+                .messageId(message.getId())
+                .teamId(message.getTeamId())
+                .senderId(message.getSenderId())
+                .senderName(message.getSenderName())
+                .content(message.getContent())
+                .type(message.getType())
+                .createdAt(message.getTimestamp())
+                .build();
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/enums/TeamChatEventType.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/enums/TeamChatEventType.java
@@ -1,0 +1,6 @@
+package com.writingboard.server.domain.teamchat.enums;
+
+public enum TeamChatEventType {
+    NEW_MESSAGE,
+    DELETE_MESSAGE
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/enums/TeamChatMessageType.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/enums/TeamChatMessageType.java
@@ -1,0 +1,5 @@
+package com.writingboard.server.domain.teamchat.enums;
+
+public enum TeamChatMessageType {
+    TEXT
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/exception/TeamChatErrorCode.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/exception/TeamChatErrorCode.java
@@ -1,0 +1,22 @@
+package com.writingboard.server.domain.teamchat.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TeamChatErrorCode {
+
+    EMPTY_MESSAGE(HttpStatus.BAD_REQUEST, "TEAM_CHAT_001", "메시지 내용이 비어있습니다"),
+    MESSAGE_TOO_LONG(HttpStatus.BAD_REQUEST, "TEAM_CHAT_002", "메시지가 너무 깁니다 (최대 2000자)"),
+    NOT_TEAM_MEMBER(HttpStatus.FORBIDDEN, "TEAM_CHAT_003", "팀 멤버가 아닙니다"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_CHAT_004", "사용자를 찾을 수 없습니다"),
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEAM_CHAT_005", "메시지를 찾을 수 없습니다"),
+    NOT_MESSAGE_SENDER(HttpStatus.FORBIDDEN, "TEAM_CHAT_006", "본인이 보낸 메시지만 삭제할 수 있습니다"),
+    TEAM_MISMATCH(HttpStatus.BAD_REQUEST, "TEAM_CHAT_007", "해당 팀의 메시지가 아닙니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/exception/TeamChatException.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/exception/TeamChatException.java
@@ -1,0 +1,14 @@
+package com.writingboard.server.domain.teamchat.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TeamChatException extends RuntimeException {
+
+    private final TeamChatErrorCode errorCode;
+
+    public TeamChatException(TeamChatErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/repository/TeamChatMessageRepository.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/repository/TeamChatMessageRepository.java
@@ -1,0 +1,11 @@
+package com.writingboard.server.domain.teamchat.repository;
+
+import com.writingboard.server.domain.teamchat.document.TeamChatMessage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface TeamChatMessageRepository extends MongoRepository<TeamChatMessage, String> {
+
+    Page<TeamChatMessage> findByTeamIdOrderByTimestampDesc(Long teamId, Pageable pageable);
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/service/TeamChatRedisPublisher.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/service/TeamChatRedisPublisher.java
@@ -1,0 +1,48 @@
+package com.writingboard.server.domain.teamchat.service;
+
+import com.writingboard.server.domain.teamchat.dto.response.TeamChatEventDto;
+import com.writingboard.server.domain.teamchat.dto.response.TeamChatMessageResponse;
+import com.writingboard.server.domain.teamchat.enums.TeamChatEventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamChatRedisPublisher {
+
+    private static final String CHANNEL_PREFIX = "teamchat:team:";
+
+    private final RedisTemplate<String, TeamChatEventDto> teamChatRedisTemplate;
+
+    public void publishNewMessage(Long teamId, TeamChatMessageResponse message) {
+        TeamChatEventDto event = TeamChatEventDto.builder()
+                .eventType(TeamChatEventType.NEW_MESSAGE)
+                .message(message)
+                .build();
+
+        publish(teamId, event);
+    }
+
+    public void publishDeleteMessage(Long teamId, String messageId) {
+        TeamChatEventDto event = TeamChatEventDto.builder()
+                .eventType(TeamChatEventType.DELETE_MESSAGE)
+                .messageId(messageId)
+                .build();
+
+        publish(teamId, event);
+    }
+
+    private void publish(Long teamId, TeamChatEventDto event) {
+        String channel = CHANNEL_PREFIX + teamId;
+
+        try {
+            teamChatRedisTemplate.convertAndSend(channel, event);
+            log.debug("팀 채팅 Redis 메시지 발행: channel={}, eventType={}", channel, event.getEventType());
+        } catch (Exception e) {
+            log.error("팀 채팅 Redis 메시지 발행 실패: channel={}", channel, e);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/service/TeamChatRedisSubscriber.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/service/TeamChatRedisSubscriber.java
@@ -1,0 +1,43 @@
+package com.writingboard.server.domain.teamchat.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.writingboard.server.domain.teamchat.dto.response.TeamChatEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamChatRedisSubscriber implements MessageListener {
+
+    private static final String CHANNEL_PREFIX = "teamchat:team:";
+    private static final String TOPIC_PREFIX = "/topic/team/";
+    private static final String TOPIC_SUFFIX = "/chat";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel());
+            String body = new String(message.getBody());
+
+            TeamChatEventDto event = objectMapper.readValue(body, TeamChatEventDto.class);
+            String teamId = channel.replace(CHANNEL_PREFIX, "");
+
+            String destination = TOPIC_PREFIX + teamId + TOPIC_SUFFIX;
+            messagingTemplate.convertAndSend(destination, event);
+
+            log.debug("팀 채팅 클라이언트로 메시지 전송: destination={}, eventType={}",
+                    destination, event.getEventType());
+
+        } catch (Exception e) {
+            log.error("팀 채팅 Redis 메시지 처리 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/domain/teamchat/service/TeamChatService.java
+++ b/src/main/java/com/writingboard/server/domain/teamchat/service/TeamChatService.java
@@ -1,0 +1,99 @@
+package com.writingboard.server.domain.teamchat.service;
+
+import com.writingboard.server.domain.member.entity.Member;
+import com.writingboard.server.domain.member.repository.MemberRepository;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
+import com.writingboard.server.domain.teamchat.document.TeamChatMessage;
+import com.writingboard.server.domain.teamchat.dto.request.TeamChatMessageRequest;
+import com.writingboard.server.domain.teamchat.dto.response.TeamChatMessageResponse;
+import com.writingboard.server.domain.teamchat.exception.TeamChatErrorCode;
+import com.writingboard.server.domain.teamchat.exception.TeamChatException;
+import com.writingboard.server.domain.teamchat.repository.TeamChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.HtmlUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TeamChatService {
+
+    private static final int MAX_MESSAGE_LENGTH = 2000;
+
+    private final TeamChatMessageRepository teamChatMessageRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
+    private final TeamChatRedisPublisher redisPublisher;
+
+    public Page<TeamChatMessageResponse> getMessages(Long memberId, Long teamId, Pageable pageable) {
+        validateTeamMember(teamId, memberId);
+
+        Page<TeamChatMessage> page = teamChatMessageRepository.findByTeamIdOrderByTimestampDesc(teamId, pageable);
+        return page.map(TeamChatMessageResponse::from);
+    }
+
+    public TeamChatMessageResponse sendMessage(Long memberId, Long teamId, TeamChatMessageRequest request) {
+        validateTeamMember(teamId, memberId);
+        validateContent(request.getContent());
+
+        String sanitizedContent = HtmlUtils.htmlEscape(request.getContent());
+
+        Member sender = memberRepository.findById(memberId)
+                .orElseThrow(() -> new TeamChatException(TeamChatErrorCode.MEMBER_NOT_FOUND));
+
+        TeamChatMessage message = TeamChatMessage.createText(teamId, sender, sanitizedContent);
+        teamChatMessageRepository.save(message);
+
+        TeamChatMessageResponse response = TeamChatMessageResponse.from(message);
+
+        redisPublisher.publishNewMessage(teamId, response);
+
+        log.debug("팀 채팅 메시지 전송 완료: teamId={}, senderId={}, messageId={}",
+                teamId, memberId, message.getId());
+
+        return response;
+    }
+
+    public void deleteMessage(Long memberId, Long teamId, String messageId) {
+        validateTeamMember(teamId, memberId);
+
+        TeamChatMessage message = teamChatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new TeamChatException(TeamChatErrorCode.MESSAGE_NOT_FOUND));
+
+        if (!message.getTeamId().equals(teamId)) {
+            throw new TeamChatException(TeamChatErrorCode.TEAM_MISMATCH);
+        }
+
+        if (!message.getSenderId().equals(memberId)) {
+            throw new TeamChatException(TeamChatErrorCode.NOT_MESSAGE_SENDER);
+        }
+
+        teamChatMessageRepository.delete(message);
+
+        redisPublisher.publishDeleteMessage(teamId, messageId);
+
+        log.debug("팀 채팅 메시지 삭제 완료: teamId={}, memberId={}, messageId={}",
+                teamId, memberId, messageId);
+    }
+
+    private void validateTeamMember(Long teamId, Long memberId) {
+        boolean isMember = teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(
+                teamId, memberId, TeamMemberStatus.ACTIVE);
+        if (!isMember) {
+            throw new TeamChatException(TeamChatErrorCode.NOT_TEAM_MEMBER);
+        }
+    }
+
+    private void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new TeamChatException(TeamChatErrorCode.EMPTY_MESSAGE);
+        }
+        if (content.length() > MAX_MESSAGE_LENGTH) {
+            throw new TeamChatException(TeamChatErrorCode.MESSAGE_TOO_LONG);
+        }
+    }
+}

--- a/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/RedisPubSubConfig.java
@@ -8,6 +8,8 @@ import com.writingboard.server.domain.drawing.dto.response.DrawingStrokeDto;
 import com.writingboard.server.domain.drawing.service.DrawingRedisSubscriber;
 import com.writingboard.server.domain.meeting.dto.FollowStateDto;
 import com.writingboard.server.domain.meeting.service.FollowRedisSubscriber;
+import com.writingboard.server.domain.teamchat.dto.response.TeamChatEventDto;
+import com.writingboard.server.domain.teamchat.service.TeamChatRedisSubscriber;
 import com.writingboard.server.domain.voice.dto.response.VoiceSignalDto;
 import com.writingboard.server.domain.voice.service.VoiceRedisSubscriber;
 import org.springframework.context.annotation.Bean;
@@ -28,7 +30,8 @@ public class RedisPubSubConfig {
             ChatRedisSubscriber chatRedisSubscriber,
             DrawingRedisSubscriber drawingRedisSubscriber,
             VoiceRedisSubscriber voiceRedisSubscriber,
-            FollowRedisSubscriber followRedisSubscriber) {
+            FollowRedisSubscriber followRedisSubscriber,
+            TeamChatRedisSubscriber teamChatRedisSubscriber) {
 
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(redisConnectionFactory);
@@ -44,6 +47,9 @@ public class RedisPubSubConfig {
 
         // follow:room:* 패턴의 모든 채널 구독
         container.addMessageListener(followRedisSubscriber, new PatternTopic("follow:room:*"));
+
+        // teamchat:team:* 패턴의 모든 채널 구독
+        container.addMessageListener(teamChatRedisSubscriber, new PatternTopic("teamchat:team:*"));
 
         return container;
     }
@@ -121,6 +127,26 @@ public class RedisPubSubConfig {
 
         Jackson2JsonRedisSerializer<FollowStateDto> serializer =
                 new Jackson2JsonRedisSerializer<>(objectMapper, FollowStateDto.class);
+
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, TeamChatEventDto> teamChatRedisTemplate(
+            RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, TeamChatEventDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        Jackson2JsonRedisSerializer<TeamChatEventDto> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper, TeamChatEventDto.class);
 
         template.setValueSerializer(serializer);
         template.afterPropertiesSet();

--- a/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/writingboard/server/global/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package com.writingboard.server.global.config;
 import com.writingboard.server.domain.auth.jwt.JwtProvider;
 import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
 import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
 import com.writingboard.server.global.websocket.JwtHandshakeInterceptor;
 import com.writingboard.server.global.websocket.StompChannelInterceptor;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final JwtProvider jwtProvider;
     private final RoomRepository roomRepository;
     private final RoomParticipantRepository participantRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -40,7 +42,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(
-                new StompChannelInterceptor(jwtProvider, roomRepository, participantRepository)
+                new StompChannelInterceptor(jwtProvider, roomRepository, participantRepository, teamMemberRepository)
         );
     }
 }

--- a/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/writingboard/server/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.writingboard.server.domain.meeting.exception.MeetingException;
 import com.writingboard.server.domain.member.exception.MemberException;
 import com.writingboard.server.domain.personal.exception.PersonalException;
 import com.writingboard.server.domain.team.exception.TeamException;
+import com.writingboard.server.domain.teamchat.exception.TeamChatException;
 import com.writingboard.server.domain.voice.exception.VoiceException;
 import com.writingboard.server.global.common.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -79,6 +80,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(PersonalException.class)
     public ResponseEntity<ErrorResponse> handlePersonalException(PersonalException e) {
         log.warn("PersonalException: {}", e.getMessage());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(TeamChatException.class)
+    public ResponseEntity<ErrorResponse> handleTeamChatException(TeamChatException e) {
+        log.warn("TeamChatException: {}", e.getMessage());
         return ResponseEntity
                 .status(e.getErrorCode().getStatus())
                 .body(ErrorResponse.of(e.getErrorCode().getCode(), e.getMessage()));

--- a/src/main/java/com/writingboard/server/global/websocket/StompChannelInterceptor.java
+++ b/src/main/java/com/writingboard/server/global/websocket/StompChannelInterceptor.java
@@ -4,6 +4,8 @@ import com.writingboard.server.domain.auth.jwt.JwtProvider;
 import com.writingboard.server.domain.meeting.entity.enums.ParticipantState;
 import com.writingboard.server.domain.meeting.repository.RoomParticipantRepository;
 import com.writingboard.server.domain.meeting.repository.RoomRepository;
+import com.writingboard.server.domain.team.entity.enums.TeamMemberStatus;
+import com.writingboard.server.domain.team.repository.TeamMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -21,6 +23,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
     private final JwtProvider jwtProvider;
     private final RoomRepository roomRepository;
     private final RoomParticipantRepository participantRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -102,6 +105,25 @@ public class StompChannelInterceptor implements ChannelInterceptor {
             log.debug("SUBSCRIBE 허용: memberId={}, roomUuid={}, dest={}",
                     memberId, roomUuid, destination);
         }
+
+        if (destination != null && destination.startsWith("/topic/team/") && destination.endsWith("/chat")) {
+            Long memberId = getMemberId(accessor);
+
+            if (memberId == null) {
+                throw new MessagingException("인증되지 않은 사용자입니다.");
+            }
+
+            Long teamId = extractTeamId(destination);
+
+            if (!isTeamMember(teamId, memberId)) {
+                log.warn("팀 채팅 SUBSCRIBE 거부: memberId={}, teamId={}, dest={}",
+                        memberId, teamId, destination);
+                throw new MessagingException("해당 팀의 멤버가 아닙니다.");
+            }
+
+            log.debug("팀 채팅 SUBSCRIBE 허용: memberId={}, teamId={}, dest={}",
+                    memberId, teamId, destination);
+        }
     }
 
     private String extractRoomUuid(String destination) {
@@ -121,5 +143,16 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                 .map(room -> participantRepository.existsByRoomIdAndMemberIdAndState(
                         room.getId(), memberId, ParticipantState.JOINED))
                 .orElse(false);
+    }
+
+    private Long extractTeamId(String destination) {
+        // /topic/team/{teamId}/chat
+        String[] parts = destination.split("/");
+        return parts.length >= 4 ? Long.parseLong(parts[3]) : null;
+    }
+
+    private boolean isTeamMember(Long teamId, Long memberId) {
+        return teamMemberRepository.existsByTeamIdAndMemberIdAndStatus(
+                teamId, memberId, TeamMemberStatus.ACTIVE);
     }
 }


### PR DESCRIPTION
Summary
팀별 채팅 (Per-Team Chat): REST API(메시지 조회/전송/삭제) + STOMP 실시간 메시지 푸시 (/topic/team/{teamId}/chat)
팀별 개인 프로필 (Per-Team Profile): 팀마다 닉네임/프로필 이미지를 Summary
팀별 채팅 (Per-Team Chat): REST API(메시지 조회/전송/삭제) + STOMP 실시간 메시지 푸시 (/topic/team/{teamId}/chat)
팀별 개인 프로필 (Per-Team Profile): 팀마다 닉네임/프로필 이미지를 개별 설정할 수 있는 기능 (multipart 이미지 업로드 포함)
회의 일정 캘린더 (Meeting Schedule Calendar): 팀별 일정 CRUD + 반복 규칙(DAILY/WEEKLY/MONTHLY) 지원, 기간별 조회
Changes
1. Per-Team Chat (teamchat domain)
TeamChatController — GET/POST/DELETE /api/teams/{teamId}/chat/messages
TeamChatMessage (MongoDB document) — 메시지 저장
TeamChatRedisPublisher/Subscriber — STOMP 실시간 브로드캐스트
페이지네이션 조회, 본인 메시지만 삭제 가능
2. Per-Team Personal Profile (team domain 확장)
TeamMemberController — GET/PUT /api/teams/{teamId}/members/me/profile, PUT .../profile-image
TeamMember 엔티티에 nickname, profileImageUrl 필드 추가
TeamProfileResponse, TeamProfileUpdateRequest DTO 추가
3. Meeting Schedule Calendar (team domain 확장)
TeamScheduleController — GET/POST/PUT/DELETE /api/teams/{teamId}/schedules
TeamSchedule 엔티티 + RecurrenceRule Embeddable (frequency, interval, daysOfWeek, endDate)
TeamScheduleRepository — 기간별 조회 쿼리 (단건 일정 + 반복 일정)
RecurrenceFrequency enum — DAILY, WEEKLY, MONTHLY개별 설정할 수 있는 기능 (multipart 이미지 업로드 포함)
회의 일정 캘린더 (Meeting Schedule Calendar): 팀별 일정 CRUD + 반복 규칙(DAILY/WEEKLY/MONTHLY) 지원, 기간별 조회
Changes
1. Per-Team Chat (teamchat domain)
TeamChatController — GET/POST/DELETE /api/teams/{teamId}/chat/messages
TeamChatMessage (MongoDB document) — 메시지 저장
TeamChatRedisPublisher/Subscriber — STOMP 실시간 브로드캐스트
페이지네이션 조회, 본인 메시지만 삭제 가능
2. Per-Team Personal Profile (team domain 확장)
TeamMemberController — GET/PUT /api/teams/{teamId}/members/me/profile, PUT .../profile-image
TeamMember 엔티티에 nickname, profileImageUrl 필드 추가
TeamProfileResponse, TeamProfileUpdateRequest DTO 추가
3. Meeting Schedule Calendar (team domain 확장)
TeamScheduleController — GET/POST/PUT/DELETE /api/teams/{teamId}/schedules
TeamSchedule 엔티티 + RecurrenceRule Embeddable (frequency, interval, daysOfWeek, endDate)
TeamScheduleRepository — 기간별 조회 쿼리 (단건 일정 + 반복 일정)
RecurrenceFrequency enum — DAILY, WEEKLY, MONTHLY